### PR TITLE
Child Command Patch

### DIFF
--- a/src/main/java/me/jagrosh/jdautilities/commandclient/Command.java
+++ b/src/main/java/me/jagrosh/jdautilities/commandclient/Command.java
@@ -51,15 +51,12 @@ public abstract class Command {
     	// child check
         if(!event.getArgs().equalsIgnoreCase(event.getRawArgs()))
         {
-        	for(Command child : children)
+        	for(Command child : children) for(String cname : event.getRawArgs().replace(event.getArgs(), "").trim().split("\\s+"))
         	{
-        		for(int i = 0; i < event.getRawArgs().replaceFirst(event.getArgs(), "").trim().split("\\s+").length; i++)
+        		if(child.getName().equalsIgnoreCase(cname))
         		{
-        			if(child.getName().equalsIgnoreCase(event.getRawArgs().replaceFirst(event.getArgs(), "").trim().split("\\s+")[i]))
-        			{
-        				child.run(event);
-        				return;
-        			}
+        			child.run(event);
+        			return;
         		}
         	}
         }
@@ -192,6 +189,11 @@ public abstract class Command {
         return name;
     }
     
+    public String[] getAliases()
+    {
+    	return aliases;
+    }
+    
     public String getHelp()
     {
         return help;
@@ -211,7 +213,7 @@ public abstract class Command {
     {
     	return children;
     }
-
+   
     public Permission[] getUserPermissions()
     {
         return userPermissions;

--- a/src/main/java/me/jagrosh/jdautilities/commandclient/Command.java
+++ b/src/main/java/me/jagrosh/jdautilities/commandclient/Command.java
@@ -22,6 +22,7 @@ import net.dv8tion.jda.core.entities.ChannelType;
 import net.dv8tion.jda.core.entities.VoiceChannel;
 import net.dv8tion.jda.core.utils.PermissionUtil;
 
+
 /**
  *
  * @author John Grosh (jagrosh)

--- a/src/main/java/me/jagrosh/jdautilities/commandclient/Command.java
+++ b/src/main/java/me/jagrosh/jdautilities/commandclient/Command.java
@@ -22,7 +22,6 @@ import net.dv8tion.jda.core.entities.ChannelType;
 import net.dv8tion.jda.core.entities.VoiceChannel;
 import net.dv8tion.jda.core.utils.PermissionUtil;
 
-
 /**
  *
  * @author John Grosh (jagrosh)
@@ -48,19 +47,22 @@ public abstract class Command {
     
     public final void run(CommandEvent event)
     {
-        // child check
-        if(event.getChildName()!=null)
+    	// child check
+        if(!event.getArgs().equalsIgnoreCase(event.getRawArgs()))
         {
-            for(Command child : children)
-            {
-                if(child.getName()==event.getChildName())
-                {
-                    child.run(event);
-                    return;
-                }
-            }
+        	for(Command child : children)
+        	{
+        		for(int i = 0; i < event.getRawArgs().replaceFirst(event.getArgs(), "").trim().split("\\s+").length; i++)
+        		{
+        			if(child.getName().equalsIgnoreCase(event.getRawArgs().replaceFirst(event.getArgs(), "").trim().split("\\s+")[i]))
+        			{
+        				child.run(event);
+        				return;
+        			}
+        		}
+        	}
         }
-        
+    	
         // owner check
         if(ownerCommand && !event.getAuthor().getId().equals(event.getClient().getOwnerId()))
         {
@@ -203,6 +205,12 @@ public abstract class Command {
     {
         return arguments;
     }
+    
+    public Command[] getChildren()
+    {
+    	return children;
+    }
+   
     
     public Permission[] getUserPermissions()
     {

--- a/src/main/java/me/jagrosh/jdautilities/commandclient/Command.java
+++ b/src/main/java/me/jagrosh/jdautilities/commandclient/Command.java
@@ -36,6 +36,7 @@ public abstract class Command {
     protected String requiredRole = null;
     protected boolean ownerCommand = false;
     protected int cooldown = 0;
+    protected Command[] children = new Command[0];
     protected Permission[] userPermissions = new Permission[0];
     protected Permission[] botPermissions = new Permission[0];
     protected String[] aliases = new String[0];
@@ -47,6 +48,19 @@ public abstract class Command {
     
     public final void run(CommandEvent event)
     {
+        // child check
+        if(event.getChildName()!=null)
+        {
+            for(Command child : children)
+            {
+                if(child.getName()==event.getChildName())
+                {
+                    child.run(event);
+                    return;
+                }
+            }
+        }
+        
         // owner check
         if(ownerCommand && !event.getAuthor().getId().equals(event.getClient().getOwnerId()))
         {

--- a/src/main/java/me/jagrosh/jdautilities/commandclient/Command.java
+++ b/src/main/java/me/jagrosh/jdautilities/commandclient/Command.java
@@ -200,8 +200,6 @@ public abstract class Command {
         return botPermissions;
     }
     
-    public 
-    
     public boolean isOwnerCommand()
     {
         return ownerCommand;

--- a/src/main/java/me/jagrosh/jdautilities/commandclient/Command.java
+++ b/src/main/java/me/jagrosh/jdautilities/commandclient/Command.java
@@ -190,6 +190,18 @@ public abstract class Command {
         return arguments;
     }
     
+    public Permission[] getUserPermissions()
+    {
+        return userPermissions;
+    }
+    
+    public Permission[] getBotPermissions()
+    {
+        return botPermissions;
+    }
+    
+    public 
+    
     public boolean isOwnerCommand()
     {
         return ownerCommand;

--- a/src/main/java/me/jagrosh/jdautilities/commandclient/CommandEvent.java
+++ b/src/main/java/me/jagrosh/jdautilities/commandclient/CommandEvent.java
@@ -18,7 +18,6 @@ package me.jagrosh.jdautilities.commandclient;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-
 import net.dv8tion.jda.client.entities.Group;
 import net.dv8tion.jda.core.JDA;
 import net.dv8tion.jda.core.MessageBuilder;

--- a/src/main/java/me/jagrosh/jdautilities/commandclient/CommandEvent.java
+++ b/src/main/java/me/jagrosh/jdautilities/commandclient/CommandEvent.java
@@ -36,6 +36,7 @@ public class CommandEvent {
     private final MessageReceivedEvent event;
     private final String args;
     private final CommandClient client;
+    private final String childName;
     
     /**
      * Constructor for a CommandEvent. You should not call this! It is a
@@ -45,11 +46,12 @@ public class CommandEvent {
      * @param args the arguments after the command
      * @param client the commandclient
      */
-    public CommandEvent(MessageReceivedEvent event, String args, CommandClient client)
+    public CommandEvent(MessageReceivedEvent event, String args, CommandClient client, String childName)
     {
         this.event = event;
         this.args = args == null ? "" : args;
         this.client = client;
+        this.childName = childName;
     }
     
     /**
@@ -81,6 +83,15 @@ public class CommandEvent {
         return client;
     }
     
+    /**
+     * Returns the name of a child command if the arguments trigger it, otherwise null.
+     
+     * @return the name of a child command if one is triggered, otherwise null.
+     */
+    public String getChildName()
+    {
+        return childName;
+    }
     
     // functional calls
     

--- a/src/main/java/me/jagrosh/jdautilities/commandclient/CommandEvent.java
+++ b/src/main/java/me/jagrosh/jdautilities/commandclient/CommandEvent.java
@@ -18,6 +18,7 @@ package me.jagrosh.jdautilities.commandclient;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+
 import net.dv8tion.jda.client.entities.Group;
 import net.dv8tion.jda.core.JDA;
 import net.dv8tion.jda.core.MessageBuilder;
@@ -36,7 +37,7 @@ public class CommandEvent {
     private final MessageReceivedEvent event;
     private final String args;
     private final CommandClient client;
-    private final String childName;
+    private final String childArgs;
     
     /**
      * Constructor for a CommandEvent. You should not call this! It is a
@@ -46,22 +47,33 @@ public class CommandEvent {
      * @param args the arguments after the command
      * @param client the commandclient
      */
-    public CommandEvent(MessageReceivedEvent event, String args, CommandClient client, String childName)
+    public CommandEvent(MessageReceivedEvent event, String args, CommandClient client, String childArgs)
     {
-        this.event = event;
+    	this.event = event;
         this.args = args == null ? "" : args;
         this.client = client;
-        this.childName = childName;
+        this.childArgs = childArgs;
     }
     
     /**
-     * Returns the user's text input for the command
+     * Returns the user's text input for the command. When child commands
+     * are triggered, this will return the child arguments.
      * 
      * @return never-null arguments that a user has supplied to a command
      */
     public String getArgs()
     {
-        return args;
+        return args.equalsIgnoreCase(childArgs)? args : childArgs;
+    }
+    
+    /**
+     * Returns the user's raw text input for the command
+     * 
+     * @return never-null arguments that a user has supplied to a command
+     */
+    public String getRawArgs()
+    {
+    	return args;
     }
     
     /**
@@ -83,15 +95,6 @@ public class CommandEvent {
         return client;
     }
     
-    /**
-     * Returns the name of a child command if the arguments trigger it, otherwise null.
-     
-     * @return the name of a child command if one is triggered, otherwise null.
-     */
-    public String getChildName()
-    {
-        return childName;
-    }
     
     // functional calls
     

--- a/src/main/java/me/jagrosh/jdautilities/commandclient/impl/CommandClientImpl.java
+++ b/src/main/java/me/jagrosh/jdautilities/commandclient/impl/CommandClientImpl.java
@@ -286,18 +286,18 @@ public class CommandClientImpl extends ListenerAdapter implements CommandClient 
     private String getSpecifiedArgs(Command command, String args) 
     {
     	Command[] children = command.getChildren();
-    	if(children.length==0) //If no child commands
-    		return args; //return arguments provided, untouched
+    	if(children.length==0)
+    		return args;
     	Command child;
-    	try{ //attempts getting child by name
+    	try{
     		child = Arrays.asList(children).stream().filter(c -> args.toLowerCase().startsWith(c.getName())).findFirst().get();
-    	} catch(NoSuchElementException e) { //If no child command is found, returns provided arguments
+    	} catch(NoSuchElementException e) {
     		return args;
     	}
-    	String specArgs = null; //Specified arguments are left empty.
-    	if(child.getChildren().length>0) //If there exists more children, it will attempt to get further specified arguments
+    	String specArgs = null;
+    	if(child.getChildren().length>0)
     		specArgs = getSpecifiedArgs(child, args.replaceFirst(child.getName(), "").trim());
-    	else //Otherwise the specified arguments are set and returned
+    	else
     		specArgs = args.replaceFirst(child.getName(), "").trim();
     	return specArgs;
     	

--- a/src/main/java/me/jagrosh/jdautilities/commandclient/impl/CommandClientImpl.java
+++ b/src/main/java/me/jagrosh/jdautilities/commandclient/impl/CommandClientImpl.java
@@ -245,7 +245,7 @@ public class CommandClientImpl extends ListenerAdapter implements CommandClient 
             if(parts[0].equalsIgnoreCase("help"))
             {
                 isCommand[0] = true;
-                CommandEvent cevent = new CommandEvent(event, parts[1]==null ? "" : parts[1], this);
+                CommandEvent cevent = new CommandEvent(event, parts[1]==null ? "" : parts[1], this, null);
                 if(listener!=null)
                     listener.onCommand(cevent, null);
                 List<String> messages = CommandEvent.splitMessage(helpFunction.apply(cevent));
@@ -270,7 +270,7 @@ public class CommandClientImpl extends ListenerAdapter implements CommandClient 
                     isCommand[0] = true;
                     CommandEvent cevent = null;
                     Command[] children = command.getChildren();
-                    if(children>0)
+                    if(children.length>0)
                     {
                         for(Command child : children)
                         {

--- a/src/main/java/me/jagrosh/jdautilities/commandclient/impl/CommandClientImpl.java
+++ b/src/main/java/me/jagrosh/jdautilities/commandclient/impl/CommandClientImpl.java
@@ -268,8 +268,8 @@ public class CommandClientImpl extends ListenerAdapter implements CommandClient 
                 String args = parts[1]==null ? "" : parts[1];
                 commands.stream().filter(cmd -> cmd.isCommandFor(name)).findAny().ifPresent(command -> {
                     isCommand[0] = true;
-                    String specArgs = getSpecifiedArgs(command, args);
-                    CommandEvent cevent = new CommandEvent(event, args, this, specArgs);
+                    String childArgs = getChildArgs(command, args);
+                    CommandEvent cevent = new CommandEvent(event, args, this, childArgs);
                     if(listener!=null)
                         listener.onCommand(cevent, command);
                     if(isAllowed(command, event.getTextChannel()))
@@ -283,7 +283,7 @@ public class CommandClientImpl extends ListenerAdapter implements CommandClient 
             listener.onNonCommandMessage(event);
     }
     
-    private String getSpecifiedArgs(Command command, String args) 
+    private String getChildArgs(Command command, String args) 
     {
     	Command[] children = command.getChildren();
     	if(children.length==0)
@@ -294,12 +294,12 @@ public class CommandClientImpl extends ListenerAdapter implements CommandClient 
     	} catch(NoSuchElementException e) {
     		return args;
     	}
-    	String specArgs = null;
+    	String childArgs = null;
     	if(child.getChildren().length>0)
-    		specArgs = getSpecifiedArgs(child, args.replaceFirst(child.getName(), "").trim());
+    		childArgs = getChildArgs(child, args.replaceFirst(child.getName(), "").trim());
     	else
-    		specArgs = args.replaceFirst(child.getName(), "").trim();
-    	return specArgs;
+    		childArgs = args.replaceFirst(child.getName(), "").trim();
+    	return childArgs;
     	
     }
 

--- a/src/main/java/me/jagrosh/jdautilities/commandclient/impl/CommandClientImpl.java
+++ b/src/main/java/me/jagrosh/jdautilities/commandclient/impl/CommandClientImpl.java
@@ -268,7 +268,21 @@ public class CommandClientImpl extends ListenerAdapter implements CommandClient 
                 String args = parts[1]==null ? "" : parts[1];
                 commands.stream().filter(cmd -> cmd.isCommandFor(name)).findAny().ifPresent(command -> {
                     isCommand[0] = true;
-                    CommandEvent cevent = new CommandEvent(event, args, this);
+                    CommandEvent cevent = null;
+                    Command[] children = command.getChildren();
+                    if(children>0)
+                    {
+                        for(Command child : children)
+                        {
+                            String[] childParts = args.split("\\s+", 2);
+                            String childName = childParts[0];
+                            String childArgs = childParts[1]==null ? "" : childParts[1];
+                            if(childName.toLowerCase()==child.getName().toLowerCase())
+                                cevent = new CommandEvent(event, childArgs, this, childName);
+                        }
+                    }
+                    if(cevent==null)
+                        new CommandEvent(event, args, this, null);
                     if(listener!=null)
                         listener.onCommand(cevent, command);
                     if(isAllowed(command, event.getTextChannel()))


### PR DESCRIPTION
+ __Command.java__
    + Added children Command Array field.
    + Added overarching "child check" to Command#run.
    + Added Command#getAliases and Command#getChildren methods to retrieve the corresponding fields.
+ __CommandEvent.java__
    + Added childArgs String field.
    + Added childArgs String parameter to CommandEvent Object.
    + Added CommandEvent#getRawArgs method and documentation to get raw arguments provided.
    + Modified CommandEvent#getArgs so it would return childArgs if childArgs did not match the raw arguments provided. Also modified documentation to properly describe the new returns.
+ __CommandClientImpl.java__
    + Added CommandClientImpl#getChildArgs method to get properly trimmed child command arguments.
    + Modified several CommandEvent calls so they would work with the modifications to CommandEvent.java above.
    + Removed an unused import `import java.util.concurrent.TimeUnit;`