### PR TITLE
Fixes an issue with the command client co owner id

### DIFF
--- a/src/main/java/com/jagrosh/jdautilities/commandclient/impl/CommandClientImpl.java
+++ b/src/main/java/com/jagrosh/jdautilities/commandclient/impl/CommandClientImpl.java
@@ -115,7 +115,7 @@ public class CommandClientImpl extends ListenerAdapter implements CommandClient 
 
         if(coOwnerIds!=null) {
             for(String coOwnerId : coOwnerIds) {
-                if(SafeIdUtil.checkId(coOwnerId))
+                if(!SafeIdUtil.checkId(coOwnerId))
                     LOG.warn(String.format("The provided CoOwner ID (%s) was found unsafe! Make sure ID is a non-negative long!", coOwnerId));
             }
         }


### PR DESCRIPTION
This fixes an issue where the command client would say a provided co owner id is invalid, when in fact it is valid.