### PR TITLE
Merge feature/annotations to development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@
 
 # project files
 /src/test
+tokens.json

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,14 @@ group = 'com.jagrosh'
 archivesBaseName = project.name
 version = versionObj.toString()
 
+sourceSets {
+    main.java.srcDirs += 'src/main/java'
+    test {
+        compileClasspath = main.compileClasspath
+        runtimeClasspath = main.runtimeClasspath
+    }
+}
+
 repositories {
     jcenter()
     maven { url 'https://mvnrepository.com/artifact/' }
@@ -39,6 +47,8 @@ repositories {
 
 dependencies {
     compileOnly "net.dv8tion:JDA:${jdaVersion}"
+
+    testCompileOnly group: 'junit', name: 'junit', version: '4.12'
 }
 
 task sourcesForRelease(type: Copy) {

--- a/src/main/java/com/jagrosh/jdautilities/commandclient/AnnotatedCommandCompiler.java
+++ b/src/main/java/com/jagrosh/jdautilities/commandclient/AnnotatedCommandCompiler.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2016 John Grosh (jagrosh).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jagrosh.jdautilities.commandclient;
+
+import com.jagrosh.jdautilities.commandclient.annotation.JDACommand;
+import net.dv8tion.jda.core.utils.SimpleLog;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.MalformedParametersException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Predicate;
+
+/**
+ * A "compiler" for {@link java.lang.Object Object}s that uses {@link java.lang.annotation.Annotation Annotation}s
+ * as helpers for creating {@link com.jagrosh.jdautilities.commandclient.Command Command}s.
+ *
+ * <p>Previous to version 1.6 all Commands required the Command abstract class to be extended in source.
+ * The primary issue that came with this was that Commands were restricted to that method of creation, offering
+ * no support for popular means such as annotated commands.
+ *
+ * <p>Since 1.6 the introduction of {@link com.jagrosh.jdautilities.commandclient.CommandBuilder CommandBuilder}
+ * has allowed the potential to create unique {@link com.jagrosh.jdautilities.commandclient.Command Command}
+ * objects after compilation.
+ * <br>The primary duty of this class is to provide a "in runtime" converter for generics that are annotated with
+ * the {@link JDACommand.Module JDACommand.Module}
+ *
+ * @since  1.7
+ * @author Kaidan Gustave
+ */
+public class AnnotatedCommandCompiler
+{
+    private static final SimpleLog LOG = SimpleLog.getLog("Annotated Compiler");
+
+    public List<Command> compileModule(Object o)
+    {
+        JDACommand.Module module = o.getClass().getAnnotation(JDACommand.Module.class);
+        if(module == null) // TODO
+            throw new IllegalArgumentException("");
+        if(module.value().length<1) // TODO
+            throw new IllegalArgumentException("");
+
+        List<Method> commands = collect((Method method) -> {
+            for(String name : module.value())
+            {
+                if(name.equalsIgnoreCase(method.getName()))
+                    return true;
+            }
+            return false;
+        }, o.getClass().getMethods());
+
+        List<Command> list = new ArrayList<>();
+        commands.forEach(method -> {
+            try {
+                list.add(compile(o, method));
+            } catch(MalformedParametersException e) {
+                LOG.fatal(e.getMessage());
+            }
+        });
+        return list;
+    }
+
+    private Command compile(Object o, Method method) throws MalformedParametersException
+    {
+        JDACommand properties = method.getAnnotation(JDACommand.class);
+        if(properties == null) // TODO
+            throw new IllegalArgumentException("");
+        CommandBuilder builder = new CommandBuilder();
+
+        // Name
+        String[] names = properties.name();
+        builder.setName(names.length < 1 ? "null" : names[0]);
+
+        // Aliases
+        if(names.length>1)
+            for(int i = 1; i<names.length; i++)
+                builder.addAlias(names[i]);
+
+        // Help
+        builder.setHelp(properties.help());
+
+        // Arguments
+        builder.setArguments(properties.arguments().trim().isEmpty()? null : properties.arguments().trim());
+
+        // Guild Only
+        builder.setGuildOnly(properties.guildOnly());
+
+        // Required Role
+        builder.setRequiredRole(properties.requiredRole().trim().isEmpty()? null : properties.requiredRole().trim());
+
+        // Owner Command
+        builder.setOwnerCommand(properties.ownerCommand());
+
+        // Cooldown Delay
+        builder.setCooldown(properties.cooldown().value());
+
+        // Cooldown Scope
+        builder.setCooldownScope(properties.cooldown().scope());
+
+        // Bot Permissions
+        builder.setBotPermissions(properties.botPermissions());
+
+        // User Permissions
+        builder.setUserPermissions(properties.userPermissions());
+
+        // Uses Topic Tags
+        builder.setUsesTopicTags(properties.useTopicTags());
+
+        // Child Commands
+        if(properties.children().length>0)
+        {
+            collect((Method m) -> {
+                for(String cName : properties.children())
+                {
+                    if(cName.equalsIgnoreCase(m.getName()))
+                        return true;
+                }
+                return false;
+            }, o.getClass().getMethods()).forEach(cm -> {
+                try {
+                    builder.addChild(compile(o, cm));
+                } catch(MalformedParametersException e) {
+                    LOG.fatal(e.getMessage());
+                }
+            });
+        }
+
+
+        Class<?>[] parameters = method.getParameterTypes();
+        // Dual Parameter Command, CommandEvent
+        if(parameters[0] == Command.class && parameters[1] == CommandEvent.class)
+        {
+            return builder.build((command, event) -> {
+                try {
+                    method.invoke(o, command, event);
+                } catch(IllegalAccessException | InvocationTargetException e) {
+                    LOG.log(e);
+                }
+            });
+        }
+        else if(parameters[0] == CommandEvent.class)
+        {
+            // Single parameter CommandEvent
+            if(parameters.length == 1)
+                return builder.build(event -> {
+                    try {
+                        method.invoke(o, event);
+                    } catch(IllegalAccessException | InvocationTargetException e) {
+                        LOG.log(e);
+                    }
+                });
+            // Dual Parameter CommandEvent, Command
+            else if(parameters[1] == Command.class)
+                return builder.build((command, event) -> {
+                    try {
+                        method.invoke(o, event, command);
+                    } catch(IllegalAccessException | InvocationTargetException e) {
+                        LOG.log(e);
+                    }
+                });
+        }
+
+        // If we reach this point there is a malformed method and we shouldn't finish the compilation.
+        throw new MalformedParametersException(
+                "Method named "+method.getName()+" was not compiled due to improper parameter types!");
+    }
+
+    @SafeVarargs
+    private static <T> List<T> collect(Predicate<T> filter, T... entities)
+    {
+        List<T> list = new ArrayList<>();
+        for(T entity : entities)
+        {
+            if(filter.test(entity))
+                list.add(entity);
+        }
+        return list;
+    }
+
+}

--- a/src/main/java/com/jagrosh/jdautilities/commandclient/CommandClientBuilder.java
+++ b/src/main/java/com/jagrosh/jdautilities/commandclient/CommandClientBuilder.java
@@ -54,7 +54,7 @@ public class CommandClientBuilder {
     private String helpWord;
     private ScheduledExecutorService executor;
     private int linkedCacheSize = 200;
-    private AnnotatedCommandCompiler compiler = null;
+    private AnnotatedModuleCompiler compiler = null;
     
     /**
      * Builds a {@link com.jagrosh.jdautilities.commandclient.impl.CommandClientImpl CommandClientImpl} 
@@ -342,15 +342,15 @@ public class CommandClientBuilder {
      *
      * @return This builder
      *
-     * @see    com.jagrosh.jdautilities.commandclient.AnnotatedCommandCompiler
+     * @see    AnnotatedModuleCompiler
      * @see    com.jagrosh.jdautilities.commandclient.annotation.JDACommand
      */
     public CommandClientBuilder addAnnotatedModule(Object module)
     {
         if(compiler == null)
-            compiler = new AnnotatedCommandCompiler();
+            compiler = new AnnotatedModuleCompiler();
 
-        this.commands.addAll(compiler.compileModule(module));
+        this.commands.addAll(compiler.compile(module));
 
         return this;
     }
@@ -368,7 +368,7 @@ public class CommandClientBuilder {
      *
      * @return This builder
      *
-     * @see    com.jagrosh.jdautilities.commandclient.AnnotatedCommandCompiler
+     * @see    AnnotatedModuleCompiler
      * @see    com.jagrosh.jdautilities.commandclient.annotation.JDACommand
      */
     public CommandClientBuilder addAnnotatedModules(Object... modules)

--- a/src/main/java/com/jagrosh/jdautilities/commandclient/CommandClientBuilder.java
+++ b/src/main/java/com/jagrosh/jdautilities/commandclient/CommandClientBuilder.java
@@ -54,6 +54,7 @@ public class CommandClientBuilder {
     private String helpWord;
     private ScheduledExecutorService executor;
     private int linkedCacheSize = 200;
+    private AnnotatedCommandCompiler compiler = null;
     
     /**
      * Builds a {@link com.jagrosh.jdautilities.commandclient.impl.CommandClientImpl CommandClientImpl} 
@@ -328,7 +329,55 @@ public class CommandClientBuilder {
             this.addCommand(command);
         return this;
     }
-    
+
+    /**
+     * Adds an annotated command module to the
+     * {@link com.jagrosh.jdautilities.commandclient.impl.CommandClientImpl CommandClientImpl} for this session.
+     *
+     * <p>For more information on annotated command modules, see
+     * {@link com.jagrosh.jdautilities.commandclient.annotation the annotation package} documentation.
+     *
+     * @param  module
+     *         The annotated command module to add
+     *
+     * @return This builder
+     *
+     * @see    com.jagrosh.jdautilities.commandclient.AnnotatedCommandCompiler
+     * @see    com.jagrosh.jdautilities.commandclient.annotation.JDACommand
+     */
+    public CommandClientBuilder addAnnotatedModule(Object module)
+    {
+        if(compiler == null)
+            compiler = new AnnotatedCommandCompiler();
+
+        this.commands.addAll(compiler.compileModule(module));
+
+        return this;
+    }
+
+    /**
+     * Adds multiple annotated command modules to the
+     * {@link com.jagrosh.jdautilities.commandclient.impl.CommandClientImpl CommandClientImpl} for this session.
+     * <br>This is the same as calling {@link CommandClientBuilder#addAnnotatedModule(Object)} multiple times.
+     *
+     * <p>For more information on annotated command modules, see
+     * {@link com.jagrosh.jdautilities.commandclient.annotation the annotation package} documentation.
+     *
+     * @param  modules
+     *         The annotated command modules to add
+     *
+     * @return This builder
+     *
+     * @see    com.jagrosh.jdautilities.commandclient.AnnotatedCommandCompiler
+     * @see    com.jagrosh.jdautilities.commandclient.annotation.JDACommand
+     */
+    public CommandClientBuilder addAnnotatedModules(Object... modules)
+    {
+        for(Object command : modules)
+            addAnnotatedModule(command);
+        return this;
+    }
+
     /**
      * Sets the <a href="https://www.carbonitex.net/discord/bots">Carbonitex</a> key for this bot's listing.
      * 

--- a/src/main/java/com/jagrosh/jdautilities/commandclient/annotation/JDACommand.java
+++ b/src/main/java/com/jagrosh/jdautilities/commandclient/annotation/JDACommand.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2016 John Grosh (jagrosh).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jagrosh.jdautilities.commandclient.annotation;
+
+import com.jagrosh.jdautilities.commandclient.Command;
+import net.dv8tion.jda.core.Permission;
+
+import java.lang.annotation.*;
+
+/**
+ * An Annotation applicable to {@link java.lang.reflect.Method Method}s that will act as
+ * {@link com.jagrosh.jdautilities.commandclient.Command Command}s when added to a Client
+ * using {@link com.jagrosh.jdautilities.commandclient.CommandClientBuilder#addAnnotatedModule(Object)
+ * CommandClientBuilder#addAnnotatedModule()} serving as metadata "constructors" for what
+ * would be a class extending Command of the same functionality and settings.
+ *
+ * <p>The primary issue that command systems face when trying to implement "annotated command"
+ * systems is that reflection is a powerful but also costly tool and requires much more overhead
+ * than most other types systems.
+ *
+ * To circumvent this, classes annotated with this are put through an {@link
+ * com.jagrosh.jdautilities.commandclient.AnnotatedCommandCompiler AnnotatedCommandCompiler}.
+ * where they will be converted to Commands using {@link com.jagrosh.jdautilities.commandclient.CommandBuilder
+ * CommandBuilder}.
+ *
+ * <p>Classes that wish to be contain methods to be used as commands must be annotated with
+ * {@link com.jagrosh.jdautilities.commandclient.annotation.JDACommand.Module @Module}.
+ * <br>Following that, any methods of said class annotated with this annotation (whose names
+ * are also given as parameters of the {@code @Module} annotation) will be registered to the
+ * module and "compiled" through the AnnotatedCommandCompiler provided in CommandClientBuilder.
+ *
+ * @see    com.jagrosh.jdautilities.commandclient.annotation.JDACommand.Module
+ *
+ * @since  1.7
+ * @author Kaidan Gustave
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface JDACommand
+{
+    /**
+     * The name and aliases of the command.
+     *
+     * <p>The first index is the name, and following indices are aliases.
+     *
+     * @return An array of strings, the first one being the name
+     * of the command, and following ones being aliases.
+     */
+    String[] name() default {"null"};
+
+    /**
+     * The help string for a command.
+     *
+     * @return The help string for a command.
+     */
+    String help() default "no help available";
+
+    /**
+     * Whether or not the command is only usable in a guild.
+     * <br>Default {@code true}.
+     *
+     * @return {@code true} if the command can only be used in a guild,
+     * {@code false} otherwise.
+     */
+    boolean guildOnly() default true;
+
+    /**
+     * The name of a role required to use this command.
+     *
+     * @return The name of a role required to use this command.
+     */
+    String requiredRole() default "";
+
+    /**
+     * Whether or not the command is owner only.
+     * <br>Default {@code true}.
+     *
+     * @return {@code true} if the command is owner only, {@code false} otherwise.
+     */
+    boolean ownerCommand() default false;
+
+    /**
+     * The arguments string for the command.
+     *
+     * @return The arguments string for the command.
+     */
+    String arguments() default "";
+
+    /**
+     * The {@link com.jagrosh.jdautilities.commandclient.annotation.JDACommand.Cooldown
+     * JDACommand.Cooldown} for the command.
+     *
+     * <p>This holds both metadata for both the
+     * {@link com.jagrosh.jdautilities.commandclient.Command#cooldown Command#cooldown}
+     * and {@link com.jagrosh.jdautilities.commandclient.Command#cooldownScope
+     * Command#cooldownScope}.
+     *
+     * @return The {@code @Cooldown} for the command.
+     */
+    Cooldown cooldown() default @Cooldown(0);
+
+    /**
+     * The {@link net.dv8tion.jda.core.Permission Permissions} the bot must have
+     * on a guild to use this command.
+     *
+     * @return The required permissions the bot must have to use this command.
+     */
+    Permission[] botPermissions() default {};
+
+    /**
+     * The {@link net.dv8tion.jda.core.Permission Permissions} the user must have
+     * on a guild to use this command.
+     *
+     * @return The required permissions a user must have to use this command.
+     */
+    Permission[] userPermissions() default {};
+
+    /**
+     * Whether or not this command uses topic tags.
+     * <br>Default {@code true}.
+     *
+     * <p>For more information on topic tags, see
+     * {@link com.jagrosh.jdautilities.commandclient.Command#usesTopicTags
+     * Command#usesTopicTags}
+     *
+     * @return {@code true} if this command uses topic tags, {@code false} otherwise.
+     */
+    boolean useTopicTags() default true;
+
+    /**
+     * The names of any methods representing child commands for this command.
+     *
+     * @return The names of any methods representing child commands.
+     */
+    String[] children() default {};
+
+    /**
+     * A helper annotation to assist in location of methods that will
+     * generate into {@link com.jagrosh.jdautilities.commandclient.Command
+     * Command}s.
+     *
+     * @see    com.jagrosh.jdautilities.commandclient.annotation.JDACommand
+     */
+    @Target(ElementType.TYPE)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface Module
+    {
+        /**
+         * The names of any methods that will be targeted when compiling this object using the
+         * {@link com.jagrosh.jdautilities.commandclient.AnnotatedCommandCompiler
+         * AnnotatedCommandCompiler}.
+         *
+         * @return An array of method names used when creating commands.
+         */
+        String[] value();
+    }
+
+    /**
+     * A value wrapper for what would be {@link com.jagrosh.jdautilities.commandclient.Command#cooldown
+     * Command#cooldown} and {@link com.jagrosh.jdautilities.commandclient.Command#cooldownScope
+     * Command#cooldownScope}.
+     *
+     * The default {@link com.jagrosh.jdautilities.commandclient.Command.CooldownScope CooldownScope}
+     * is {@link com.jagrosh.jdautilities.commandclient.Command.CooldownScope#USER CooldownScope.USER}.
+     */
+    @Target(ElementType.TYPE)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface Cooldown
+    {
+        int value();
+
+        Command.CooldownScope scope() default Command.CooldownScope.USER;
+    }
+}


### PR DESCRIPTION
This new feature adds full support for annotation driven commands.

New Files:
+ `AnnotatedModuleCompiler.java` - A "compiler" that converts generic `Object`s into `Command`s.
+ `JDACommand.java` - An annotation for containing metadata used in creation of `Command`s through `AnnotatedModuleCompiler`.

This is untested, and requires a little testing, but should be ready to go otherwise.

I would highly appreciate some design comments, possible redesigns, or modifications to code to make more efficient.

**Edit:** I posted a gist [here](https://gist.github.com/TheMonitorLizard/a075b088092173bd298cb5ab850b51e1) which is a small example bot that makes usage of annotated commands.