### PR TITLE
Shard manager additions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ plugins {
 }
 
 def versionObj = new Version(major: 1, minor: 9)
-def jdaVersion = 'b55c183'
+def jdaVersion = '3.3.1_309'
 
 group = 'com.jagrosh'
 archivesBaseName = project.name
@@ -42,12 +42,11 @@ sourceSets {
 
 repositories {
     jcenter()
-    maven { url 'https://jitpack.io/' }
     maven { url 'https://mvnrepository.com/artifact/' }
 }
 
 dependencies {
-    compileOnly "com.github.DV8FromTheWorld:JDA:${jdaVersion}"
+    compileOnly "net.dv8tion:JDA:${jdaVersion}"
 
     testCompileOnly group: 'junit', name: 'junit', version: '4.12'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ plugins {
 }
 
 def versionObj = new Version(major: 1, minor: 9)
-def jdaVersion = '3.3.1_284'
+def jdaVersion = 'b55c183'
 
 group = 'com.jagrosh'
 archivesBaseName = project.name
@@ -42,11 +42,12 @@ sourceSets {
 
 repositories {
     jcenter()
+    maven { url 'https://jitpack.io/' }
     maven { url 'https://mvnrepository.com/artifact/' }
 }
 
 dependencies {
-    compileOnly "net.dv8tion:JDA:${jdaVersion}"
+    compileOnly "com.github.DV8FromTheWorld:JDA:${jdaVersion}"
 
     testCompileOnly group: 'junit', name: 'junit', version: '4.12'
 }

--- a/src/main/java/com/jagrosh/jdautilities/commandclient/Command.java
+++ b/src/main/java/com/jagrosh/jdautilities/commandclient/Command.java
@@ -549,6 +549,10 @@ public abstract class Command
             case GUILD:        return event.getGuild()!=null ? cooldownScope.genKey(name,event.getGuild().getIdLong()) :
                     CooldownScope.CHANNEL.genKey(name,event.getChannel().getIdLong());
             case CHANNEL:      return cooldownScope.genKey(name,event.getChannel().getIdLong());
+            case SHARD:        return event.getJDA().getShardInfo()!=null ? cooldownScope.genKey(name, event.getJDA().getShardInfo().getShardId()) :
+                    CooldownScope.GLOBAL.genKey(name, 0);
+            case USER_SHARD:   return event.getJDA().getShardInfo()!=null ? cooldownScope.genKey(name,event.getAuthor().getIdLong(),event.getJDA().getShardInfo().getShardId()) :
+                    CooldownScope.USER.genKey(name, event.getAuthor().getIdLong());
             case GLOBAL:       return cooldownScope.genKey(name, 0);
             default:           return "";
         }
@@ -743,6 +747,7 @@ public abstract class Command
          * </ul>
          */
         USER("U:%d",""),
+
         /**
          * Applies the cooldown to the {@link net.dv8tion.jda.core.entities.MessageChannel MessageChannel} the
          * command is called in.
@@ -753,6 +758,7 @@ public abstract class Command
          * </ul>
          */
         CHANNEL("C:%d","in this channel"),
+
         /**
          * Applies the cooldown to the calling {@link net.dv8tion.jda.core.entities.User User} local to the
          * {@link net.dv8tion.jda.core.entities.MessageChannel MessageChannel} the command is called in.
@@ -763,6 +769,7 @@ public abstract class Command
          * </ul>
          */
         USER_CHANNEL("U:%d|C:%d", "in this channel"),
+
         /**
          * Applies the cooldown to the {@link net.dv8tion.jda.core.entities.Guild Guild} the command is called in.
          *
@@ -776,6 +783,7 @@ public abstract class Command
          * {@link java.lang.NullPointerException NullPointerException}s from being thrown while generating cooldown keys!
          */
         GUILD("G:%d", "in this server"),
+
         /**
          * Applies the cooldown to the calling {@link net.dv8tion.jda.core.entities.User User} local to the
          * {@link net.dv8tion.jda.core.entities.Guild Guild} the command is called in.
@@ -790,6 +798,38 @@ public abstract class Command
          * {@link java.lang.NullPointerException NullPointerException}s from being thrown while generating cooldown keys!
          */
         USER_GUILD("U:%d|G:%d", "in this server"),
+
+        /**
+         * Applies the cooldown to the calling Shard the command is called on.
+         *
+         * <p>The key for this is generated in the format
+         * <ul>
+         *     {@code <command-name>|S:<shardID>}
+         * </ul>
+         *
+         * <p><b>NOTE:</b> This will automatically default back to {@link CooldownScope#GLOBAL CooldownScope.GLOBAL}
+         * when {@link net.dv8tion.jda.core.JDA#getShardInfo() JDA#getShardInfo()} returns {@code null}.
+         * This is done in order to prevent internal {@link java.lang.NullPointerException NullPointerException}s
+         * from being thrown while generating cooldown keys!
+         */
+        SHARD("S:%d", "on this shard"),
+
+        /**
+         * Applies the cooldown to the calling {@link net.dv8tion.jda.core.entities.User User} on the Shard
+         * the command is called on.
+         *
+         * <p>The key for this is generated in the format
+         * <ul>
+         *     {@code <command-name>|U:<userID>|S:<shardID>}
+         * </ul>
+         *
+         * <p><b>NOTE:</b> This will automatically default back to {@link CooldownScope#USER CooldownScope.USER}
+         * when {@link net.dv8tion.jda.core.JDA#getShardInfo() JDA#getShardInfo()} returns {@code null}.
+         * This is done in order to prevent internal {@link java.lang.NullPointerException NullPointerException}s
+         * from being thrown while generating cooldown keys!
+         */
+        USER_SHARD("U:%d|S:%d", "on this shard"),
+
         /**
          * Applies this cooldown globally.
          *

--- a/src/main/java/com/jagrosh/jdautilities/commandclient/Command.java
+++ b/src/main/java/com/jagrosh/jdautilities/commandclient/Command.java
@@ -732,8 +732,12 @@ public abstract class Command
      * @see    com.jagrosh.jdautilities.commandclient.Command#cooldownScope Command.cooldownScope
      *
      * @apiNote
-     *         These are effective across a single instance of JDA, and not multiple ones.
-     *         <br>There is no shard magic, no 100% "global" cooldown, unless via some external system.
+     *         These are effective across a single instance of JDA, and not multiple
+     *         ones, save when multiple shards run on a single JVM and under a
+     *         {@link net.dv8tion.jda.bot.sharding.ShardManager ShardManager}.
+     *         <br>There is no shard magic, and no guarantees for a 100% "global"
+     *         cooldown, unless all shards of the bot run under the same ShardManager,
+     *         and/or via some external system unrelated to JDA-Utilities.
      */
     public enum CooldownScope
     {


### PR DESCRIPTION
+ Added ShardManager compatibility with FinderUtil
+ Added CooldownScopes for `SHARD` and `USER_SHARD`

FinderUtil should have full compatibility with ShardManager.

I opted to separate methods for targeting a single shard and targeting a ShardManager, and creating a new method that only targets the JDA instance.
Non-sharded bots will not have to worry, as the previously existing methods only target ShardManager when one is present, otherwise the target the specified JDA instance as they would normally.

Unfortunately this means that if users used this before with the intention of targeting the specific JDA instance, they will have to convert `FinderUtil.findX` to `FinderUtil.findShardX` where applicable.

@Almighty-Alpaca I would appreciate some feedback from you as you seem to be the most active JDA dev working on `experimental/shard-manager` and would be able to correct me if I misunderstood the functionality of certain methods and/or ShardManager features.

**Note:** This PR is pre-staged and should be merged *after* `experimental/shard-manager` is merged to JDA `master`.