### PR TITLE
Development 1.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ You will need to add this project as a dependency (either from the latest .jar f
   <dependency>
     <groupId>com.jagrosh</groupId>
     <artifactId>JDA-Utilities</artifactId>
-    <version>1.8</version>
+    <version>1.9</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -47,7 +47,7 @@ You will need to add this project as a dependency (either from the latest .jar f
 With gradle:
 ```groovy
 dependencies {
-    compile 'com.jagrosh:JDA-Utilities:1.8'
+    compile 'com.jagrosh:JDA-Utilities:1.9'
     compile 'net.dv8tion:JDA:LATEST'
 }
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [issueslink]: https://github.com/JDA-Applications/JDA-Utilities/issues
 
 [ ![version][] ][download]
-[ ![license][] ](https://github.com/DV8FromTheWorld/JDA/tree/master/LICENSE)
+[ ![license][] ](https://github.com/JDA-Applications/JDA-Utilities/tree/master/LICENSE)
 [ ![issues][] ][issueslink]
 
 ## JDA-Utilities

--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+[version]: https://api.bintray.com/packages/jagrosh/maven/JDA-Utilities/images/download.svg
+[download]: https://bintray.com/jagrosh/maven/JDA-Utilities/_latestVersion
+[license]: https://img.shields.io/badge/License-Apache%202.0-lightgrey.svg
+[issues]: https://img.shields.io/github/issues/JDA-Applications/JDA-Utilities.svg 
+[issueslink]: https://github.com/JDA-Applications/JDA-Utilities/issues
+
+[ ![version][] ][download]
+[ ![license][] ](https://github.com/DV8FromTheWorld/JDA/tree/master/LICENSE)
+[ ![issues][] ][issueslink]
+
 ## JDA-Utilities
 JDA-Utilities is a series of tools and utilities for use with [JDA](https://github.com/DV8FromTheWorld/JDA) to assist in bot creation.
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,17 @@
 ## JDA-Utilities
 JDA-Utilities is a series of tools and utilities for use with [JDA](https://github.com/DV8FromTheWorld/JDA) to assist in bot creation.
 
+## Version 2.0 Notice
+Version 2.0 will be a come with a lot of big (some breaking) changes to the library.
+
+If you use this library for anything, it is **STRONGLY** recommended you read [this gist](https://gist.github.com/TheMonitorLizard/4f09ac2a3c9d8019dc3cde02cc456eee)
+which documents all of the changes that will be made, as to better prepare yourself for moving to 2.0.
+
+Note that the gist is in no way final, and will be modified possibly until the day that we release 2.0,
+so it's a good idea to keep up-to-date with it in the coming weeks.
+
+If you have questions or concerns about any of these changes, please contact **Shengaero**#9090.
+
 ## Getting Started
 You will need to add this project as a dependency (either from the latest .jar from the releases page, or via maven or gradle), as well as [JDA](https://github.com/DV8FromTheWorld/JDA). With maven, you can use the snippets below:
 ```xml

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ plugins {
 }
 
 def versionObj = new Version(major: 1, minor: 9)
-def jdaVersion = '3.3.1_309'
+def jdaVersion = '3.3.1_313'
 
 group = 'com.jagrosh'
 archivesBaseName = project.name

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ plugins {
 }
 
 def versionObj = new Version(major: 1, minor: 9)
-def jdaVersion = '3.3.1_284'
+def jdaVersion = '3.3.1_309'
 
 group = 'com.jagrosh'
 archivesBaseName = project.name

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ plugins {
     id 'com.github.johnrengelman.shadow' version '2.0.1'
 }
 
-def versionObj = new Version(major: 1, minor: 8)
+def versionObj = new Version(major: 1, minor: 9)
 def jdaVersion = '3.3.1_284'
 
 group = 'com.jagrosh'

--- a/src/main/java/com/jagrosh/jdautilities/JDAUtilitiesInfo.java
+++ b/src/main/java/com/jagrosh/jdautilities/JDAUtilitiesInfo.java
@@ -21,7 +21,7 @@ package com.jagrosh.jdautilities;
  */
 public class JDAUtilitiesInfo {
     public static final String VERSION_MAJOR = "1";
-    public static final String VERSION_MINOR = "8";
+    public static final String VERSION_MINOR = "9";
     public static final String VERSION = VERSION_MAJOR+"."+VERSION_MINOR;
     public static final String GITHUB = "https://github.com/JDA-Applications/JDA-Utilities";
     public static final String AUTHOR = "JDA-Applications";

--- a/src/main/java/com/jagrosh/jdautilities/commandclient/AnnotatedModuleCompiler.java
+++ b/src/main/java/com/jagrosh/jdautilities/commandclient/AnnotatedModuleCompiler.java
@@ -45,7 +45,8 @@ public interface AnnotatedModuleCompiler
      * <p><b>This Object must be annotated with {@link
      * com.jagrosh.jdautilities.commandclient.annotation.JDACommand.Module @JDACommand.Module}!</b>
      *
-     * @param  o The Object, annotated with {@code @JDACommand.Module}.
+     * @param  o
+     *         The Object, annotated with {@code @JDACommand.Module}.
      *
      * @return A {@link java.util.List} of Commands generated from the provided Object
      */

--- a/src/main/java/com/jagrosh/jdautilities/commandclient/Command.java
+++ b/src/main/java/com/jagrosh/jdautilities/commandclient/Command.java
@@ -149,6 +149,12 @@ public abstract class Command
      * <br>Default {@code true}.
      */
     protected boolean usesTopicTags = true;
+    
+    /**
+     * {@code true} if this command should be hidden from the help.
+     * <br>Default {@code false}
+     */
+    protected boolean hidden = false;
 
     /**
      * The {@link com.jagrosh.jdautilities.commandclient.Command.CooldownScope CooldownScope}
@@ -503,6 +509,16 @@ public abstract class Command
     public boolean isOwnerCommand()
     {
         return ownerCommand;
+    }
+    
+    /**
+     * Checks whether or not this command should be hidden from the help
+     * 
+     * @return {@code true} if the command should be hidden, otherwise {@code false}
+     */
+    public boolean isHidden()
+    {
+        return hidden;
     }
     
     private void terminate(CommandEvent event, String message)

--- a/src/main/java/com/jagrosh/jdautilities/commandclient/Command.java
+++ b/src/main/java/com/jagrosh/jdautilities/commandclient/Command.java
@@ -202,7 +202,7 @@ public abstract class Command
         }
         
         // owner check
-        if(ownerCommand && !(event.isOwner() || event.isCoOwner()))
+        if(ownerCommand && !(event.isOwner()))
         {
             terminate(event,null);
             return;
@@ -230,7 +230,7 @@ public abstract class Command
                 return;
             }
         
-        // availabilty check
+        // availability check
         if(event.getChannelType()==ChannelType.TEXT)
         {
             // bot perms

--- a/src/main/java/com/jagrosh/jdautilities/commandclient/Command.java
+++ b/src/main/java/com/jagrosh/jdautilities/commandclient/Command.java
@@ -549,6 +549,10 @@ public abstract class Command
             case GUILD:        return event.getGuild()!=null ? cooldownScope.genKey(name,event.getGuild().getIdLong()) :
                     CooldownScope.CHANNEL.genKey(name,event.getChannel().getIdLong());
             case CHANNEL:      return cooldownScope.genKey(name,event.getChannel().getIdLong());
+            case SHARD:        return event.getJDA().getShardInfo()!=null ? cooldownScope.genKey(name, event.getJDA().getShardInfo().getShardId()) :
+                    CooldownScope.GLOBAL.genKey(name, 0);
+            case USER_SHARD:   return event.getJDA().getShardInfo()!=null ? cooldownScope.genKey(name,event.getAuthor().getIdLong(),event.getJDA().getShardInfo().getShardId()) :
+                    CooldownScope.USER.genKey(name, event.getAuthor().getIdLong());
             case GLOBAL:       return cooldownScope.genKey(name, 0);
             default:           return "";
         }
@@ -728,8 +732,12 @@ public abstract class Command
      * @see    com.jagrosh.jdautilities.commandclient.Command#cooldownScope Command.cooldownScope
      *
      * @apiNote
-     *         These are effective across a single instance of JDA, and not multiple ones.
-     *         <br>There is no shard magic, no 100% "global" cooldown, unless via some external system.
+     *         These are effective across a single instance of JDA, and not multiple
+     *         ones, save when multiple shards run on a single JVM and under a
+     *         {@link net.dv8tion.jda.bot.sharding.ShardManager ShardManager}.
+     *         <br>There is no shard magic, and no guarantees for a 100% "global"
+     *         cooldown, unless all shards of the bot run under the same ShardManager,
+     *         and/or via some external system unrelated to JDA-Utilities.
      */
     public enum CooldownScope
     {
@@ -743,6 +751,7 @@ public abstract class Command
          * </ul>
          */
         USER("U:%d",""),
+
         /**
          * Applies the cooldown to the {@link net.dv8tion.jda.core.entities.MessageChannel MessageChannel} the
          * command is called in.
@@ -753,6 +762,7 @@ public abstract class Command
          * </ul>
          */
         CHANNEL("C:%d","in this channel"),
+
         /**
          * Applies the cooldown to the calling {@link net.dv8tion.jda.core.entities.User User} local to the
          * {@link net.dv8tion.jda.core.entities.MessageChannel MessageChannel} the command is called in.
@@ -763,6 +773,7 @@ public abstract class Command
          * </ul>
          */
         USER_CHANNEL("U:%d|C:%d", "in this channel"),
+
         /**
          * Applies the cooldown to the {@link net.dv8tion.jda.core.entities.Guild Guild} the command is called in.
          *
@@ -776,6 +787,7 @@ public abstract class Command
          * {@link java.lang.NullPointerException NullPointerException}s from being thrown while generating cooldown keys!
          */
         GUILD("G:%d", "in this server"),
+
         /**
          * Applies the cooldown to the calling {@link net.dv8tion.jda.core.entities.User User} local to the
          * {@link net.dv8tion.jda.core.entities.Guild Guild} the command is called in.
@@ -790,6 +802,38 @@ public abstract class Command
          * {@link java.lang.NullPointerException NullPointerException}s from being thrown while generating cooldown keys!
          */
         USER_GUILD("U:%d|G:%d", "in this server"),
+
+        /**
+         * Applies the cooldown to the calling Shard the command is called on.
+         *
+         * <p>The key for this is generated in the format
+         * <ul>
+         *     {@code <command-name>|S:<shardID>}
+         * </ul>
+         *
+         * <p><b>NOTE:</b> This will automatically default back to {@link CooldownScope#GLOBAL CooldownScope.GLOBAL}
+         * when {@link net.dv8tion.jda.core.JDA#getShardInfo() JDA#getShardInfo()} returns {@code null}.
+         * This is done in order to prevent internal {@link java.lang.NullPointerException NullPointerException}s
+         * from being thrown while generating cooldown keys!
+         */
+        SHARD("S:%d", "on this shard"),
+
+        /**
+         * Applies the cooldown to the calling {@link net.dv8tion.jda.core.entities.User User} on the Shard
+         * the command is called on.
+         *
+         * <p>The key for this is generated in the format
+         * <ul>
+         *     {@code <command-name>|U:<userID>|S:<shardID>}
+         * </ul>
+         *
+         * <p><b>NOTE:</b> This will automatically default back to {@link CooldownScope#USER CooldownScope.USER}
+         * when {@link net.dv8tion.jda.core.JDA#getShardInfo() JDA#getShardInfo()} returns {@code null}.
+         * This is done in order to prevent internal {@link java.lang.NullPointerException NullPointerException}s
+         * from being thrown while generating cooldown keys!
+         */
+        USER_SHARD("U:%d|S:%d", "on this shard"),
+
         /**
          * Applies this cooldown globally.
          *

--- a/src/main/java/com/jagrosh/jdautilities/commandclient/CommandBuilder.java
+++ b/src/main/java/com/jagrosh/jdautilities/commandclient/CommandBuilder.java
@@ -55,6 +55,7 @@ public class CommandBuilder
     private BiConsumer<CommandEvent, Command> helpBiConsumer = null;
     private boolean usesTopicTags = true;
     private CooldownScope cooldownScope = CooldownScope.USER;
+    private boolean hidden = false;
 
     /**
      * Sets the {@link com.jagrosh.jdautilities.commandclient.Command#name name}
@@ -435,6 +436,20 @@ public class CommandBuilder
     }
 
     /**
+     * Sets the Command built to be {@link com.jagrosh.jdautilities.commandclient.Command#hidden hidden}
+     * from the help builder.
+     *
+     * @param  hidden
+     *         {@code true} if this will be hidden from the help builder, {@code false} otherwise.
+     *
+     * @return This CommandBuilder
+     */
+    public CommandBuilder setHidden(boolean hidden) {
+        this.hidden = hidden;
+        return this;
+    }
+
+    /**
      * Builds the {@link com.jagrosh.jdautilities.commandclient.Command Command}
      * using the previously provided information.
      *
@@ -476,7 +491,7 @@ public class CommandBuilder
                 guildOnly, requiredRole, ownerCommand, cooldown,
                 userPermissions, botPermissions, aliases.toArray(new String[aliases.size()]),
                 children.toArray(new Command[children.size()]), helpBiConsumer, usesTopicTags,
-                cooldownScope)
+                cooldownScope, hidden)
         {
             @Override
             protected void execute(CommandEvent event)
@@ -493,7 +508,7 @@ public class CommandBuilder
                      boolean ownerCommand, int cooldown, Permission[] userPermissions,
                      Permission[] botPermissions, String[] aliases, Command[] children,
                      BiConsumer<CommandEvent, Command> helpBiConsumer,
-                     boolean usesTopicTags, CooldownScope cooldownScope)
+                     boolean usesTopicTags, CooldownScope cooldownScope, boolean hidden)
         {
             this.name = name;
             this.help = help;
@@ -510,6 +525,7 @@ public class CommandBuilder
             this.helpBiConsumer = helpBiConsumer;
             this.usesTopicTags = usesTopicTags;
             this.cooldownScope = cooldownScope;
+            this.hidden = hidden;
         }
     }
 }

--- a/src/main/java/com/jagrosh/jdautilities/commandclient/CommandClient.java
+++ b/src/main/java/com/jagrosh/jdautilities/commandclient/CommandClient.java
@@ -415,7 +415,14 @@ public interface CommandClient
      *         The amount of seconds to delay for
      * @param  toQueue
      *         The RestAction to queue after the delay
+     *
+     * @deprecated
+     *         Scheduled for removal in 2.0
+     *
+     *         <p>Full information on these and other 2.0 deprecations and changes can be found
+     *         <a href="https://gist.github.com/TheMonitorLizard/4f09ac2a3c9d8019dc3cde02cc456eee">here</a>
      */
+    @Deprecated
     <T> void schedule(String name, int delay, RestAction<T> toQueue);
     
     /**
@@ -433,7 +440,11 @@ public interface CommandClient
      *         The the amount of seconds to delay for
      * @param  runnable 
      *         The Runnable to run after the delay
+     *
+     * @deprecated
+     *         Scheduled for removal in 2.0
      */
+    @Deprecated
     void schedule(String name, int delay, Runnable runnable);
     
     /**
@@ -452,7 +463,14 @@ public interface CommandClient
      *         The unit to measure the delay with
      * @param  toQueue
      *         The RestAction to queue after the delay
+     *
+     * @deprecated
+     *         Scheduled for removal in 2.0
+     *
+     *         <p>Full information on these and other 2.0 deprecations and changes can be found
+     *         <a href="https://gist.github.com/TheMonitorLizard/4f09ac2a3c9d8019dc3cde02cc456eee">here</a>
      */
+    @Deprecated
     <T> void schedule(String name, int delay, TimeUnit unit, RestAction<T> toQueue);
     
     /**
@@ -469,7 +487,14 @@ public interface CommandClient
      *         The unit to measure the delay with
      * @param  runnable
      *         The Runnable to run after the delay
+     *
+     * @deprecated
+     *         Scheduled for removal in 2.0
+     *
+     *         <p>Full information on these and other 2.0 deprecations and changes can be found
+     *         <a href="https://gist.github.com/TheMonitorLizard/4f09ac2a3c9d8019dc3cde02cc456eee">here</a>
      */
+    @Deprecated
     void schedule(String name, int delay, TimeUnit unit, Runnable runnable);
     
     /**
@@ -481,7 +506,14 @@ public interface CommandClient
      *         The name of the ScheduledFuture (can be used to cancel it later if needed)
      * @param  future
      *         The ScheduledFuture to save
+     *
+     * @deprecated
+     *         Scheduled for removal in 2.0
+     *
+     *         <p>Full information on these and other 2.0 deprecations and changes can be found
+     *         <a href="https://gist.github.com/TheMonitorLizard/4f09ac2a3c9d8019dc3cde02cc456eee">here</a>
      */
+    @Deprecated
     void saveFuture(String name, ScheduledFuture<?> future);
     
     /**
@@ -499,7 +531,14 @@ public interface CommandClient
      *         
      * @return {@code true} if there exists a ScheduledFuture corresponding to the provided name 
      *         (regardless of it's possible cancellation or expiration), otherwise {@code false}.
+     *
+     * @deprecated
+     *         Scheduled for removal in 2.0
+     *
+     *         <p>Full information on these and other 2.0 deprecations and changes can be found
+     *         <a href="https://gist.github.com/TheMonitorLizard/4f09ac2a3c9d8019dc3cde02cc456eee">here</a>
      */
+    @Deprecated
     boolean scheduleContains(String name);
     
     /**
@@ -510,7 +549,14 @@ public interface CommandClient
      * 
      * @param  name 
      *         The name of the ScheduledFuture
+     *
+     * @deprecated
+     *         Scheduled for removal in 2.0
+     *
+     *         <p>Full information on these and other 2.0 deprecations and changes can be found
+     *         <a href="https://gist.github.com/TheMonitorLizard/4f09ac2a3c9d8019dc3cde02cc456eee">here</a>
      */
+    @Deprecated
     void cancel(String name);
     
     /**
@@ -522,7 +568,14 @@ public interface CommandClient
      * 
      * @param  name
      *         The name of the ScheduledFuture to be cancelled immediately
+     *
+     * @deprecated
+     *         Scheduled for removal in 2.0
+     *
+     *         <p>Full information on these and other 2.0 deprecations and changes can be found
+     *         <a href="https://gist.github.com/TheMonitorLizard/4f09ac2a3c9d8019dc3cde02cc456eee">here</a>
      */
+    @Deprecated
     void cancelImmediately(String name);
     
     /**
@@ -532,12 +585,26 @@ public interface CommandClient
      *         The name of the ScheduledFuture to get
      *         
      * @return The ScheduledFuture corresponding to the provided name
+     *
+     * @deprecated
+     *         Scheduled for removal in 2.0
+     *
+     *         <p>Full information on these and other 2.0 deprecations and changes can be found
+     *         <a href="https://gist.github.com/TheMonitorLizard/4f09ac2a3c9d8019dc3cde02cc456eee">here</a>
      */
+    @Deprecated
     ScheduledFuture<?> getScheduledFuture(String name);
     
     /**
      * Cleans up cancelled and expired {@link java.util.concurrent.ScheduledFuture ScheduledFuture}s to reduce memory.
+     *
+     * @deprecated
+     *         Scheduled for removal in 2.0
+     *
+     *         <p>Full information on these and other 2.0 deprecations and changes can be found
+     *         <a href="https://gist.github.com/TheMonitorLizard/4f09ac2a3c9d8019dc3cde02cc456eee">here</a>
      */
+    @Deprecated
     void cleanSchedule();
 
     /**

--- a/src/main/java/com/jagrosh/jdautilities/commandclient/CommandClientBuilder.java
+++ b/src/main/java/com/jagrosh/jdautilities/commandclient/CommandClientBuilder.java
@@ -485,7 +485,11 @@ public class CommandClientBuilder
      *         The ScheduledExecutorService for the CommandClientImpl (must be a SingleThreadScheduledExecutor)
      *         
      * @return This builder
+     *
+     * @deprecated
+     *         Scheduled for removal in 2.0
      */
+    @Deprecated
     public CommandClientBuilder setScheduleExecutor(ScheduledExecutorService executor)
     {
         this.executor = executor;

--- a/src/main/java/com/jagrosh/jdautilities/commandclient/CommandClientBuilder.java
+++ b/src/main/java/com/jagrosh/jdautilities/commandclient/CommandClientBuilder.java
@@ -235,7 +235,17 @@ public class CommandClientBuilder
      *         The Game to use when the bot is ready
      *         
      * @return This builder
+     *
+     * @deprecated
+     *         This features will be removed in 2.0 due to it's availability
+     *         through {@link net.dv8tion.jda.core.JDABuilder JDABuilder}
+     *         not being more or less efficient than through the CommandClient.
+     *         <br>If you want to set your bot's game or status, you may do so through
+     *         {@link net.dv8tion.jda.core.JDABuilder#setGame(Game) JDABuilder#setGame(Game)}
+     *         or {@link net.dv8tion.jda.core.JDABuilder#setStatus(OnlineStatus)
+     *         JDABuilder#setStatus(OnlineStatus)} respectively.
      */
+    @Deprecated
     public CommandClientBuilder setGame(Game game)
     {
         this.game = game;
@@ -249,7 +259,17 @@ public class CommandClientBuilder
      *         Non-null/non-empty name of the game
      *         
      * @return This builder
+     *
+     * @deprecated
+     *         This features will be removed in 2.0 due to it's availability
+     *         through {@link net.dv8tion.jda.core.JDABuilder JDABuilder}
+     *         not being more or less efficient than through the CommandClient.
+     *         <br>If you want to set your bot's game or status, you may do so through
+     *         {@link net.dv8tion.jda.core.JDABuilder#setGame(Game) JDABuilder#setGame(Game)}
+     *         or {@link net.dv8tion.jda.core.JDABuilder#setStatus(OnlineStatus)
+     *         JDABuilder#setStatus(OnlineStatus)} respectively.
      */
+    @Deprecated
     public CommandClientBuilder setPlaying(String name)
     {
         if(name!=null && !name.isEmpty())
@@ -271,7 +291,17 @@ public class CommandClientBuilder
      *         The url of the stream (must be valid for streaming)
      *         
      * @return This builder
+     *
+     * @deprecated
+     *         This features will be removed in 2.0 due to it's availability
+     *         through {@link net.dv8tion.jda.core.JDABuilder JDABuilder}
+     *         not being more or less efficient than through the CommandClient.
+     *         <br>If you want to set your bot's game or status, you may do so through
+     *         {@link net.dv8tion.jda.core.JDABuilder#setGame(Game) JDABuilder#setGame(Game)}
+     *         or {@link net.dv8tion.jda.core.JDABuilder#setStatus(OnlineStatus)
+     *         JDABuilder#setStatus(OnlineStatus)} respectively.
      */
+    @Deprecated
     public CommandClientBuilder setStreaming(String name, String url)
     {
         if(name!=null && !name.isEmpty())
@@ -289,7 +319,17 @@ public class CommandClientBuilder
      * 'Playing <b>Type [prefix]help</b>'
      * 
      * @return This builder
+     *
+     * @deprecated
+     *         This features will be removed in 2.0 due to it's availability
+     *         through {@link net.dv8tion.jda.core.JDABuilder JDABuilder}
+     *         not being more or less efficient than through the CommandClient.
+     *         <br>If you want to set your bot's game or status, you may do so through
+     *         {@link net.dv8tion.jda.core.JDABuilder#setGame(Game) JDABuilder#setGame(Game)}
+     *         or {@link net.dv8tion.jda.core.JDABuilder#setStatus(OnlineStatus)
+     *         JDABuilder#setStatus(OnlineStatus)} respectively.
      */
+    @Deprecated
     public CommandClientBuilder useDefaultGame()
     {
         this.game = Game.of("default");
@@ -304,7 +344,17 @@ public class CommandClientBuilder
      *         The status to set
      *
      * @return This builder
+     *
+     * @deprecated
+     *         This features will be removed in 2.0 due to it's availability
+     *         through {@link net.dv8tion.jda.core.JDABuilder JDABuilder}
+     *         not being more or less efficient than through the CommandClient.
+     *         <br>If you want to set your bot's game or status, you may do so through
+     *         {@link net.dv8tion.jda.core.JDABuilder#setGame(Game) JDABuilder#setGame(Game)}
+     *         or {@link net.dv8tion.jda.core.JDABuilder#setStatus(OnlineStatus)
+     *         JDABuilder#setStatus(OnlineStatus)} respectively.
      */
+    @Deprecated
     public CommandClientBuilder setStatus(OnlineStatus status)
     {
         this.status = status;

--- a/src/main/java/com/jagrosh/jdautilities/commandclient/CommandClientBuilder.java
+++ b/src/main/java/com/jagrosh/jdautilities/commandclient/CommandClientBuilder.java
@@ -37,7 +37,7 @@ import net.dv8tion.jda.core.entities.Game;
  */
 public class CommandClientBuilder
 {
-    private Game game = Game.of("default");
+    private Game game = Game.playing("default");
     private OnlineStatus status = OnlineStatus.ONLINE;
     private String ownerId;
     private String[] coOwnerIds;

--- a/src/main/java/com/jagrosh/jdautilities/commandclient/CommandClientBuilder.java
+++ b/src/main/java/com/jagrosh/jdautilities/commandclient/CommandClientBuilder.java
@@ -163,9 +163,14 @@ public class CommandClientBuilder
      * @param  helpFunction
      *         A function to convert a {@link com.jagrosh.jdautilities.commandclient.CommandEvent CommandEvent} 
      *         to a String for a help DM.
-     *         
+     *
      * @return This builder
+     *
+     * @deprecated
+     *         Scheduled for removal in 2.0, will be replaced with a Consumer instead.
      */
+    @SuppressWarnings("DeprecatedIsStillUsed") // Suppress the link in docs
+    @Deprecated
     public CommandClientBuilder setHelpFunction(Function<CommandEvent,String> helpFunction)
     {
         this.helpFunction = helpFunction;

--- a/src/main/java/com/jagrosh/jdautilities/commandclient/CommandEvent.java
+++ b/src/main/java/com/jagrosh/jdautilities/commandclient/CommandEvent.java
@@ -744,13 +744,20 @@ public class CommandEvent
 
     /**
      * Tests whether or not the {@link net.dv8tion.jda.core.entities.User User} who triggered this
-     * event is the Owner of the bot.
+     * event is an owner of the bot.
      * 
      * @return {@code true} if the User is the Owner, else {@code false}
      */
     public boolean isOwner()
     {
-    	return event.getAuthor().getId().equals(this.getClient().getOwnerId());
+    	if(event.getAuthor().getId().equals(this.getClient().getOwnerId()))
+    	    return true;
+        if(this.getClient().getCoOwnerIds()==null)
+            return false;
+        for(String id : this.getClient().getCoOwnerIds())
+            if(id.equals(event.getAuthor().getId()))
+                return true;
+        return false;
     }
     
     /**
@@ -758,7 +765,21 @@ public class CommandEvent
      * event is a CoOwner of the bot.
      * 
      * @return {@code true} if the User is the CoOwner, else {@code false}
+     *
+     * @deprecated
+     *         Set for removal in 2.0.
+     *         <br>The idea of "co-owner" has undergone a revision.
+     *         It is a principle that trying to discriminate between an owner
+     *         and co-owner is a hindrance that idea.
+     *         <br>You should optimally try to implement your own system,
+     *         either through {@link com.jagrosh.jdautilities.commandclient.Command.Category
+     *         Categories} or through some other means.
+     *         <br>This function is now supported in one call to {@link #isOwner()}.
+     *
+     *         <p>Full information on these and other 2.0 deprecations and changes can be found
+     *         <a href="https://gist.github.com/TheMonitorLizard/4f09ac2a3c9d8019dc3cde02cc456eee">here</a>
      */
+    @Deprecated
     public boolean isCoOwner()
     {
     	if(this.getClient().getCoOwnerIds()==null)

--- a/src/main/java/com/jagrosh/jdautilities/commandclient/CommandEvent.java
+++ b/src/main/java/com/jagrosh/jdautilities/commandclient/CommandEvent.java
@@ -408,8 +408,34 @@ public class CommandEvent
      * 
      * @param  message
      *         A String message to reply with
+     *
+     * @deprecated
+     *         Scheduled for removal in 2.0, replaced with {@link #replyInDm(String)}
      */
+    @Deprecated
     public void replyInDM(String message)
+    {
+        replyInDm(message);
+    }
+
+    /**
+     * Replies with a String message sent to the calling {@link net.dv8tion.jda.core.entities.User User}'s
+     * {@link net.dv8tion.jda.core.entities.PrivateChannel PrivateChannel}.
+     *
+     * <p>If the User to be Direct Messaged does not already have a PrivateChannel
+     * open to send messages to, this method will automatically open one.
+     *
+     * <p>The {@link net.dv8tion.jda.core.requests.RestAction RestAction} returned by
+     * sending the response as a {@link net.dv8tion.jda.core.entities.Message Message}
+     * automatically does {@link net.dv8tion.jda.core.requests.RestAction#queue() RestAction#queue()}.
+     *
+     * <p><b>NOTE:</b> This alternate String message can exceed the 2000 character cap, and will
+     * be sent in two split Messages.
+     *
+     * @param  message
+     *         A String message to reply with
+     */
+    public void replyInDm(String message)
     {
         if(event.isFromType(ChannelType.PRIVATE))
             reply(message);
@@ -432,8 +458,31 @@ public class CommandEvent
      * 
      * @param  embed
      *         The MessageEmbed to reply with
+     *
+     * @deprecated
+     *         Scheduled for removal in 2.0, replaced with {@link #replyInDm(MessageEmbed)}
      */
+    @Deprecated
     public void replyInDM(MessageEmbed embed)
+    {
+        replyInDm(embed);
+    }
+
+    /**
+     * Replies with a {@link net.dv8tion.jda.core.entities.MessageEmbed MessageEmbed} sent to the
+     * calling {@link net.dv8tion.jda.core.entities.User User}'s {@link net.dv8tion.jda.core.entities.PrivateChannel PrivateChannel}.
+     *
+     * <p>If the User to be Direct Messaged does not already have a PrivateChannel
+     * open to send messages to, this method will automatically open one.
+     *
+     * <p>The {@link net.dv8tion.jda.core.requests.RestAction RestAction} returned by
+     * sending the response as a {@link net.dv8tion.jda.core.entities.Message Message}
+     * automatically does {@link net.dv8tion.jda.core.requests.RestAction#queue() RestAction#queue()}.
+     *
+     * @param  embed
+     *         The MessageEmbed to reply with
+     */
+    public void replyInDm(MessageEmbed embed)
     {
         if(event.isFromType(ChannelType.PRIVATE))
             reply(embed);

--- a/src/main/java/com/jagrosh/jdautilities/commandclient/annotation/JDACommand.java
+++ b/src/main/java/com/jagrosh/jdautilities/commandclient/annotation/JDACommand.java
@@ -160,6 +160,13 @@ public @interface JDACommand
     String[] children() default {};
 
     /**
+     * Whether or not this command should remain hidden in the help builder.
+     *
+     * @return {@code true} if this command should remain hidden, {@code false} otherwise.
+     */
+    boolean isHidden() default false;
+
+    /**
      * The {@link JDACommand.Category JDACommand.Category} for this command.
      * <br>This holds data to properly locate a <b>static field</b> representing
      * this command's {@link com.jagrosh.jdautilities.commandclient.Command.Category

--- a/src/main/java/com/jagrosh/jdautilities/commandclient/examples/GuildlistCommand.java
+++ b/src/main/java/com/jagrosh/jdautilities/commandclient/examples/GuildlistCommand.java
@@ -30,6 +30,7 @@ import net.dv8tion.jda.core.exceptions.PermissionException;
  *
  * @author John Grosh (jagrosh)
  */
+@SuppressWarnings("deprecation")
 public class GuildlistCommand extends Command {
 
     private final PaginatorBuilder pbuilder;

--- a/src/main/java/com/jagrosh/jdautilities/commandclient/impl/AnnotatedModuleCompilerImpl.java
+++ b/src/main/java/com/jagrosh/jdautilities/commandclient/impl/AnnotatedModuleCompilerImpl.java
@@ -134,6 +134,9 @@ public class AnnotatedModuleCompilerImpl implements AnnotatedModuleCompiler
         // Uses Topic Tags
         builder.setUsesTopicTags(properties.useTopicTags());
 
+        // Hidden
+        builder.setHidden(properties.isHidden());
+
         // Child Commands
         if(properties.children().length>0)
         {

--- a/src/main/java/com/jagrosh/jdautilities/commandclient/impl/CommandClientImpl.java
+++ b/src/main/java/com/jagrosh/jdautilities/commandclient/impl/CommandClientImpl.java
@@ -485,7 +485,7 @@ public class CommandClientImpl extends ListenerAdapter implements CommandClient
             return;
         boolean[] isCommand = new boolean[]{false};
         String[] parts = null;
-        String rawContent = event.getMessage().getRawContent();
+        String rawContent = event.getMessage().getContentRaw();
         if(prefix.equals(DEFAULT_PREFIX) || (altprefix!=null && altprefix.equals(DEFAULT_PREFIX)))
         {
             if(rawContent.startsWith("<@"+event.getJDA().getSelfUser().getId()+">")

--- a/src/main/java/com/jagrosh/jdautilities/commandclient/impl/CommandClientImpl.java
+++ b/src/main/java/com/jagrosh/jdautilities/commandclient/impl/CommandClientImpl.java
@@ -152,7 +152,7 @@ public class CommandClientImpl extends ListenerAdapter implements CommandClient
                 StringBuilder builder = new StringBuilder("**"+event.getSelfUser().getName()+"** commands:\n");
                 Category category = null;
                 for(Command command : commands)
-                    if(!command.isOwnerCommand() || event.isOwner() || event.isCoOwner())
+                    if(!command.isOwnerCommand() || event.isOwner())
                     {
                         if(!Objects.equals(category, command.getCategory()))
                         {
@@ -331,7 +331,7 @@ public class CommandClientImpl extends ListenerAdapter implements CommandClient
     {
         if(coOwnerIds==null)
             return null;
-        long[] ids = new long[coOwnerIds.length-1];
+        long[] ids = new long[coOwnerIds.length];
         for(int i = 0; i<coOwnerIds.length; i++)
         {
             ids[i] = Long.parseLong(coOwnerIds[i]);

--- a/src/main/java/com/jagrosh/jdautilities/commandclient/impl/CommandClientImpl.java
+++ b/src/main/java/com/jagrosh/jdautilities/commandclient/impl/CommandClientImpl.java
@@ -152,7 +152,7 @@ public class CommandClientImpl extends ListenerAdapter implements CommandClient
                 StringBuilder builder = new StringBuilder("**"+event.getSelfUser().getName()+"** commands:\n");
                 Category category = null;
                 for(Command command : commands)
-                    if(!command.isOwnerCommand() || event.isOwner())
+                    if(!command.isHidden() && (!command.isOwnerCommand() || event.isOwner()))
                     {
                         if(!Objects.equals(category, command.getCategory()))
                         {

--- a/src/main/java/com/jagrosh/jdautilities/commandclient/impl/CommandClientImpl.java
+++ b/src/main/java/com/jagrosh/jdautilities/commandclient/impl/CommandClientImpl.java
@@ -467,7 +467,7 @@ public class CommandClientImpl extends ListenerAdapter implements CommandClient
         event.getJDA().getPresence().setStatus(status==null ? OnlineStatus.ONLINE : status);
         if(game!=null)
             event.getJDA().getPresence().setGame("default".equals(game.getName()) ?
-                    Game.of("Type "+textPrefix+helpWord) :
+                    Game.playing("Type "+textPrefix+helpWord) :
                     game);
         sendStats(event.getJDA());
     }
@@ -584,7 +584,7 @@ public class CommandClientImpl extends ListenerAdapter implements CommandClient
 
             client.newCall(builder.build()).enqueue(new Callback() {
                 @Override
-                public void onResponse(Call call, Response response) throws IOException {
+                public void onResponse(Call call, Response response) {
                     log.info("Successfully send information to carbonitex.net");
                     response.close();
                 }
@@ -609,7 +609,7 @@ public class CommandClientImpl extends ListenerAdapter implements CommandClient
             
             client.newCall(builder.build()).enqueue(new Callback() {
                 @Override
-                public void onResponse(Call call, Response response) throws IOException {
+                public void onResponse(Call call, Response response) {
                     log.info("Successfully send information to discordbots.org");
                     response.close();
                 }
@@ -635,7 +635,7 @@ public class CommandClientImpl extends ListenerAdapter implements CommandClient
 
             client.newCall(builder.build()).enqueue(new Callback() {
                 @Override
-                public void onResponse(Call call, Response response) throws IOException {
+                public void onResponse(Call call, Response response) {
                     log.info("Successfully send information to bots.discord.pw");
                     response.close();
                 }

--- a/src/main/java/com/jagrosh/jdautilities/commandclient/package-info.java
+++ b/src/main/java/com/jagrosh/jdautilities/commandclient/package-info.java
@@ -24,23 +24,23 @@
  *     <li>{@link com.jagrosh.jdautilities.commandclient.AnnotatedModuleCompiler AnnotatedModuleCompiler}
  *     <br>An interface to create Commands from annotated objects (More info on annotated commands can be found in the
  *     {@link com.jagrosh.jdautilities.commandclient.annotation.JDACommand JDACommand} documentation).</li>
- *     <br>
+ *
  *     <li>{@link com.jagrosh.jdautilities.commandclient.CommandBuilder CommandBuilder}
  *     <br>An chain builder for Commands.</li>
- *     <br>
+ *
  *     <li>{@link com.jagrosh.jdautilities.commandclient.Command Command}
  *     <br>An abstract class that can be inherited by classes to create Commands compatible with the {@code CommandClientImpl}.</li>
- *     <br>
+ *
  *     <li>{@link com.jagrosh.jdautilities.commandclient.CommandClient CommandClient}
  *     <br>An interface used for getting info set when building a {@code CommandClientImpl}.</li>
- *     <br>
+ *
  *     <li>{@link com.jagrosh.jdautilities.commandclient.CommandClientBuilder CommandClientBuilder}
  *     <br>A builder system used to create a {@code CommandClientImpl} across several optional chained methods.</li>
- *     <br>
+ *
  *     <li>{@link com.jagrosh.jdautilities.commandclient.CommandEvent CommandEvent}
  *     <br>A wrapper for a {@link net.dv8tion.jda.core.events.message.MessageReceivedEvent MessageReceivedEvent}, {@code CommandClient}, and String arguments. 
  *     The main basis for carrying information to be used in Commands.</li>
- *     <br>
+ *
  *     <li>{@link com.jagrosh.jdautilities.commandclient.CommandListener CommandListener}
  *     <br>An interface to be provided to a {@code CommandClientImpl} that can provide Command operations depending on the outcome of the call.</li>
  * </ul>

--- a/src/main/java/com/jagrosh/jdautilities/commandclient/package-info.java
+++ b/src/main/java/com/jagrosh/jdautilities/commandclient/package-info.java
@@ -15,7 +15,7 @@
  */
 
 /**
- * <p>Items in this package pertain to the {@link com.jagrosh.jdautilities.commandclient.CommandClient CommandClient} and
+ * Items in this package pertain to the {@link com.jagrosh.jdautilities.commandclient.CommandClient CommandClient} and
  * {@link com.jagrosh.jdautilities.commandclient.Command Commands}.
  * 
  * <p>All of the contents are used heavily in the {@link com.jagrosh.jdautilities.commandclient.impl.CommandClientImpl CommandClientImpl}, 

--- a/src/main/java/com/jagrosh/jdautilities/menu/MenuBuilder.java
+++ b/src/main/java/com/jagrosh/jdautilities/menu/MenuBuilder.java
@@ -61,7 +61,13 @@ public abstract class MenuBuilder<T extends MenuBuilder<T, V>, V extends Menu> {
      *         The Color of the MessageEmbed
      *         
      * @return This builder
+     *
+     * @deprecated
+     *         This will be removed in 2.0 due to the bias it posses towards non-embed menus.<br>
+     *         If you wish to continue using it for your own custom Menu implementations in 2.0,
+     *         you simply have to remove the @Override annotation.
      */
+    @Deprecated
     public abstract T setColor(Color color);
         
     /**
@@ -79,7 +85,7 @@ public abstract class MenuBuilder<T extends MenuBuilder<T, V>, V extends Menu> {
     public final T setEventWaiter(EventWaiter waiter)
     {
         this.waiter = waiter;
-        return (T) this;
+        return (T)this;
     }
     
     /**

--- a/src/main/java/com/jagrosh/jdautilities/menu/MenuBuilder.java
+++ b/src/main/java/com/jagrosh/jdautilities/menu/MenuBuilder.java
@@ -25,6 +25,15 @@ import net.dv8tion.jda.core.entities.Role;
 import net.dv8tion.jda.core.entities.User;
 
 /**
+ * Scheduled for removal in 2.0, replacement will be inner class of corresponding menu.
+ * This is effective for <b>ALL MENUBUILDERS</b>. The corresponding location of these
+ * classes will also be flattened down to {@link com.jagrosh.jdautilities.menu}.
+ *
+ * <p><b>PREPARE ACCORDINGLY!</b> If you have implemented your own Menus and MenuBuilders
+ * please be ready to make adjustments to them.
+ *
+ * <p>Full information on these and other 2.0 deprecations and changes can be found
+ * <a href="https://gist.github.com/TheMonitorLizard/4f09ac2a3c9d8019dc3cde02cc456eee">here</a>
  * 
  * @author John Grosh
  */

--- a/src/main/java/com/jagrosh/jdautilities/menu/buttonmenu/ButtonMenu.java
+++ b/src/main/java/com/jagrosh/jdautilities/menu/buttonmenu/ButtonMenu.java
@@ -47,10 +47,10 @@ public class ButtonMenu extends Menu {
     private final String description;
     private final List<String> choices;
     private final Consumer<ReactionEmote> action;
-    private final Runnable cancel;
+    private final Consumer<Message> finalAction;
     
     protected ButtonMenu(EventWaiter waiter, Set<User> users, Set<Role> roles, long timeout, TimeUnit unit,
-            Color color, String text, String description, List<String> choices, Consumer<ReactionEmote> action, Runnable cancel)
+            Color color, String text, String description, List<String> choices, Consumer<ReactionEmote> action, Consumer<Message> finalAction)
     {
         super(waiter, users, roles, timeout, unit);
         this.color = color;
@@ -58,7 +58,7 @@ public class ButtonMenu extends Menu {
         this.description = description;
         this.choices = choices;
         this.action = action;
-        this.cancel = cancel;
+        this.finalAction = finalAction;
     }
 
     /**
@@ -108,11 +108,11 @@ public class ButtonMenu extends Menu {
                                     : event.getReaction().getEmote().getName();
                             if(!choices.contains(re))
                                 return false;
-                            return isValidUser(event);
+                            return isValidUser(event.getUser(), event.getGuild());
                         }, (MessageReactionAddEvent event) -> {
                             m.delete().queue();
                             action.accept(event.getReaction().getEmote());
-                        }, timeout, unit, cancel);
+                        }, timeout, unit, () -> finalAction.accept(m));
                     });
             }
         });

--- a/src/main/java/com/jagrosh/jdautilities/menu/buttonmenu/ButtonMenu.java
+++ b/src/main/java/com/jagrosh/jdautilities/menu/buttonmenu/ButtonMenu.java
@@ -34,6 +34,10 @@ import net.dv8tion.jda.core.events.message.react.MessageReactionAddEvent;
 import net.dv8tion.jda.core.requests.RestAction;
 
 /**
+ * Scheduled for reallocation in 2.0
+ *
+ * <p>Full information on these and other 2.0 deprecations and changes can be found
+ * <a href="https://gist.github.com/TheMonitorLizard/4f09ac2a3c9d8019dc3cde02cc456eee">here</a>
  *
  * @author John Grosh
  */

--- a/src/main/java/com/jagrosh/jdautilities/menu/buttonmenu/ButtonMenu.java
+++ b/src/main/java/com/jagrosh/jdautilities/menu/buttonmenu/ButtonMenu.java
@@ -103,15 +103,15 @@ public class ButtonMenu extends Menu {
                         waiter.waitForEvent(MessageReactionAddEvent.class, event -> {
                             if(!event.getMessageId().equals(m.getId()))
                                 return false;
-                            String re = event.getReaction().getEmote().isEmote() 
-                                    ? event.getReaction().getEmote().getId() 
-                                    : event.getReaction().getEmote().getName();
+                            String re = event.getReactionEmote().isEmote()
+                                    ? event.getReactionEmote().getId()
+                                    : event.getReactionEmote().getName();
                             if(!choices.contains(re))
                                 return false;
                             return isValidUser(event.getUser(), event.getGuild());
                         }, (MessageReactionAddEvent event) -> {
                             m.delete().queue();
-                            action.accept(event.getReaction().getEmote());
+                            action.accept(event.getReactionEmote());
                         }, timeout, unit, () -> finalAction.accept(m));
                     });
             }

--- a/src/main/java/com/jagrosh/jdautilities/menu/buttonmenu/ButtonMenuBuilder.java
+++ b/src/main/java/com/jagrosh/jdautilities/menu/buttonmenu/ButtonMenuBuilder.java
@@ -25,6 +25,10 @@ import net.dv8tion.jda.core.entities.Emote;
 import net.dv8tion.jda.core.entities.MessageReaction.ReactionEmote;
 
 /**
+ * Scheduled for reallocation in 2.0
+ *
+ * <p>Full information on these and other 2.0 deprecations and changes can be found
+ * <a href="https://gist.github.com/TheMonitorLizard/4f09ac2a3c9d8019dc3cde02cc456eee">here</a>
  *
  * @author John Grosh
  */

--- a/src/main/java/com/jagrosh/jdautilities/menu/buttonmenu/ButtonMenuBuilder.java
+++ b/src/main/java/com/jagrosh/jdautilities/menu/buttonmenu/ButtonMenuBuilder.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.function.Consumer;
 import com.jagrosh.jdautilities.menu.MenuBuilder;
 import net.dv8tion.jda.core.entities.Emote;
+import net.dv8tion.jda.core.entities.Message;
 import net.dv8tion.jda.core.entities.MessageReaction.ReactionEmote;
 
 /**
@@ -39,7 +40,7 @@ public class ButtonMenuBuilder extends MenuBuilder<ButtonMenuBuilder, ButtonMenu
     private String description;
     private final List<String> choices = new LinkedList<>();
     private Consumer<ReactionEmote> action;
-    private Runnable cancel = () -> {};
+    private Consumer<Message> finalAction = (m) -> {};
     
     @Override
     public ButtonMenu build() {
@@ -51,7 +52,7 @@ public class ButtonMenuBuilder extends MenuBuilder<ButtonMenuBuilder, ButtonMenu
             throw new IllegalArgumentException("Must provide an action consumer");
         if(text==null && description==null)
             throw new IllegalArgumentException("Either text or description must be set");
-        return new ButtonMenu(waiter, users, roles, timeout, unit, color, text, description, choices, action, cancel);
+        return new ButtonMenu(waiter, users, roles, timeout, unit, color, text, description, choices, action, finalAction);
     }
 
     /**
@@ -111,6 +112,24 @@ public class ButtonMenuBuilder extends MenuBuilder<ButtonMenuBuilder, ButtonMenu
         this.action = action;
         return this;
     }
+
+    /**
+     * Sets the {@link java.util.function.Consumer Consumer} to perform if the
+     * {@link com.jagrosh.jdautilities.menu.buttonmenu.ButtonMenu ButtonMenu} is done,
+     * either via cancellation, a timeout, or a selection being made.<p>
+     *
+     * This accepts the message used to display the menu when called.
+     *
+     * @param  finalAction
+     *         The Runnable action to perform if the ButtonMenu is done
+     *
+     * @return This builder
+     */
+    public ButtonMenuBuilder setFinalAction(Consumer<Message> finalAction)
+    {
+        this.finalAction = finalAction;
+        return this;
+    }
     
     /**
      * Sets the {@link java.lang.Runnable Runnable} to perform if the 
@@ -120,9 +139,13 @@ public class ButtonMenuBuilder extends MenuBuilder<ButtonMenuBuilder, ButtonMenu
      *         The Runnable action to perform if the ButtonMenu times out
      *         
      * @return This builder
+     *
+     * @deprecated
+     *         Replace with {@link ButtonMenuBuilder#setFinalAction(Consumer)}.
      */
+    @Deprecated
     public ButtonMenuBuilder setCancel(Runnable cancel) {
-        this.cancel = cancel;
+        this.finalAction = (m) -> cancel.run();
         return this;
     }
     

--- a/src/main/java/com/jagrosh/jdautilities/menu/orderedmenu/OrderedMenu.java
+++ b/src/main/java/com/jagrosh/jdautilities/menu/orderedmenu/OrderedMenu.java
@@ -159,15 +159,15 @@ public class OrderedMenu extends Menu {
                 if(e instanceof MessageReactionAddEvent)
                 {
                     MessageReactionAddEvent event = (MessageReactionAddEvent)e;
-                    if(event.getReaction().getEmote().getName().equals(CANCEL))
+                    if(event.getReactionEmote().getName().equals(CANCEL))
                         cancel.accept(m);
                     else
-                        action.accept(m, getNumber(event.getReaction().getEmote().getName()));
+                        action.accept(m, getNumber(event.getReactionEmote().getName()));
                 }
                 else if (e instanceof MessageReceivedEvent)
                 {
                     MessageReceivedEvent event = (MessageReceivedEvent)e;
-                    int num = getMessageNumber(event.getMessage().getRawContent());
+                    int num = getMessageNumber(event.getMessage().getContentRaw());
                     if(num<0 || num>choices.size())
                         cancel.accept(m);
                     else
@@ -182,10 +182,10 @@ public class OrderedMenu extends Menu {
                 return isValidReaction(m, e);
             }, e -> {
                 m.delete().queue();
-                if(e.getReaction().getEmote().getName().equals(CANCEL))
+                if(e.getReactionEmote().getName().equals(CANCEL))
                     cancel.accept(m);
                 else
-                    action.accept(m, getNumber(e.getReaction().getEmote().getName()));
+                    action.accept(m, getNumber(e.getReactionEmote().getName()));
             }, timeout, unit, () -> cancel.accept(m));
     }
     
@@ -207,9 +207,9 @@ public class OrderedMenu extends Menu {
             return false;
         if(!isValidUser(e.getUser(), e.getGuild()))
             return false;
-        if(e.getReaction().getEmote().getName().equals(CANCEL))
+        if(e.getReactionEmote().getName().equals(CANCEL))
             return true;
-        int num = getNumber(e.getReaction().getEmote().getName());
+        int num = getNumber(e.getReactionEmote().getName());
         return !(num<0 || num>choices.size());
     }
     

--- a/src/main/java/com/jagrosh/jdautilities/menu/orderedmenu/OrderedMenu.java
+++ b/src/main/java/com/jagrosh/jdautilities/menu/orderedmenu/OrderedMenu.java
@@ -39,6 +39,10 @@ import net.dv8tion.jda.core.requests.RestAction;
 import net.dv8tion.jda.core.utils.PermissionUtil;
 
 /**
+ * Scheduled for reallocation in 2.0
+ *
+ * <p>Full information on these and other 2.0 deprecations and changes can be found
+ * <a href="https://gist.github.com/TheMonitorLizard/4f09ac2a3c9d8019dc3cde02cc456eee">here</a>
  *
  * @author John Grosh
  */

--- a/src/main/java/com/jagrosh/jdautilities/menu/orderedmenu/OrderedMenuBuilder.java
+++ b/src/main/java/com/jagrosh/jdautilities/menu/orderedmenu/OrderedMenuBuilder.java
@@ -23,6 +23,10 @@ import java.util.function.Consumer;
 import com.jagrosh.jdautilities.menu.MenuBuilder;
 
 /**
+ * Scheduled for reallocation in 2.0
+ *
+ * <p>Full information on these and other 2.0 deprecations and changes can be found
+ * <a href="https://gist.github.com/TheMonitorLizard/4f09ac2a3c9d8019dc3cde02cc456eee">here</a>
  *
  * @author John Grosh
  */

--- a/src/main/java/com/jagrosh/jdautilities/menu/orderedmenu/OrderedMenuBuilder.java
+++ b/src/main/java/com/jagrosh/jdautilities/menu/orderedmenu/OrderedMenuBuilder.java
@@ -19,8 +19,10 @@ import java.awt.Color;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import com.jagrosh.jdautilities.menu.MenuBuilder;
+import net.dv8tion.jda.core.entities.Message;
 
 /**
  * Scheduled for reallocation in 2.0
@@ -36,8 +38,8 @@ public class OrderedMenuBuilder extends MenuBuilder<OrderedMenuBuilder, OrderedM
     private String text;
     private String description;
     private final List<String> choices = new LinkedList<>();
-    private Consumer<Integer> action;
-    private Runnable cancel = () -> {};
+    private BiConsumer<Message, Integer> selection;
+    private Consumer<Message> cancel = (m) -> {};
     private boolean useLetters = false;
     private boolean allowTypedInput = true;
     private boolean addCancel = false;
@@ -50,12 +52,12 @@ public class OrderedMenuBuilder extends MenuBuilder<OrderedMenuBuilder, OrderedM
             throw new IllegalArgumentException("Must have at least one choice");
         if(choices.size()>10)
             throw new IllegalArgumentException("Must have no more than ten choices");
-        if(action==null)
-            throw new IllegalArgumentException("Must provide an action consumer");
+        if(selection == null)
+            throw new IllegalArgumentException("Must provide an selection consumer");
         if(text==null && description==null)
             throw new IllegalArgumentException("Either text or description must be set");
         return new OrderedMenu(waiter,users,roles,timeout,unit,color,text,description,choices,
-                action,cancel,useLetters,allowTypedInput,addCancel);
+                selection,cancel,useLetters,allowTypedInput,addCancel);
     }
 
     /**
@@ -160,9 +162,27 @@ public class OrderedMenuBuilder extends MenuBuilder<OrderedMenuBuilder, OrderedM
      *         The Consumer action to perform upon selecting a button
      * 
      * @return This builder
+     *
+     * @deprecated
+     *         Replace with {@link OrderedMenuBuilder#setSelection(BiConsumer)}
      */
+    @Deprecated
     public OrderedMenuBuilder setAction(Consumer<Integer> action) {
-        this.action = action;
+        this.selection = (m, i) -> action.accept(i);
+        return this;
+    }
+
+    /**
+     * Sets the {@link java.util.function.BiConsumer BiConsumer} action to perform upon selecting a option.
+     *
+     * @param  selection
+     *         The BiConsumer action to perform upon selecting a button
+     *
+     * @return This builder
+     */
+    public OrderedMenuBuilder setSelection(BiConsumer<Message, Integer> selection)
+    {
+        this.selection = selection;
         return this;
     }
     
@@ -174,8 +194,27 @@ public class OrderedMenuBuilder extends MenuBuilder<OrderedMenuBuilder, OrderedM
      *         The Runnable action to perform if the ButtonMenu times out
      *         
      * @return This builder
+     *
+     * @deprecated
+     *         Replace with {@link OrderedMenuBuilder#setCancel(Consumer)}
      */
+    @Deprecated
     public OrderedMenuBuilder setCancel(Runnable cancel) {
+        this.cancel = (m) -> cancel.run();
+        return this;
+    }
+
+    /**
+     * Sets the {@link java.util.function.Consumer Consumer} to perform if the
+     * {@link com.jagrosh.jdautilities.menu.orderedmenu.OrderedMenu OrderedMenu} is cancelled.
+     *
+     * @param  cancel
+     *         The Consumer action to perform if the ButtonMenu is cancelled
+     *
+     * @return This builder
+     */
+    public OrderedMenuBuilder setCancel(Consumer<Message> cancel)
+    {
         this.cancel = cancel;
         return this;
     }

--- a/src/main/java/com/jagrosh/jdautilities/menu/pagination/Paginator.java
+++ b/src/main/java/com/jagrosh/jdautilities/menu/pagination/Paginator.java
@@ -168,7 +168,7 @@ public class Paginator extends Menu {
                     || STOP.equals(event.getReaction().getEmote().getName())
                     || RIGHT.equals(event.getReaction().getEmote().getName())))
                 return false;
-            return isValidUser(event);
+            return isValidUser(event.getUser(), event.getGuild());
         }, event -> {
             int newPageNum = pageNum;
             switch(event.getReaction().getEmote().getName())

--- a/src/main/java/com/jagrosh/jdautilities/menu/pagination/Paginator.java
+++ b/src/main/java/com/jagrosh/jdautilities/menu/pagination/Paginator.java
@@ -34,6 +34,10 @@ import net.dv8tion.jda.core.exceptions.PermissionException;
 import net.dv8tion.jda.core.requests.RestAction;
 
 /**
+ * Scheduled for reallocation in 2.0
+ *
+ * <p>Full information on these and other 2.0 deprecations and changes can be found
+ * <a href="https://gist.github.com/TheMonitorLizard/4f09ac2a3c9d8019dc3cde02cc456eee">here</a>
  *
  * @author John Grosh
  */

--- a/src/main/java/com/jagrosh/jdautilities/menu/pagination/Paginator.java
+++ b/src/main/java/com/jagrosh/jdautilities/menu/pagination/Paginator.java
@@ -164,14 +164,14 @@ public class Paginator extends Menu {
         waiter.waitForEvent(MessageReactionAddEvent.class, (MessageReactionAddEvent event) -> {
             if(!event.getMessageId().equals(message.getId()))
                 return false;
-            if(!(LEFT.equals(event.getReaction().getEmote().getName()) 
-                    || STOP.equals(event.getReaction().getEmote().getName())
-                    || RIGHT.equals(event.getReaction().getEmote().getName())))
+            if(!(LEFT.equals(event.getReactionEmote().getName())
+                    || STOP.equals(event.getReactionEmote().getName())
+                    || RIGHT.equals(event.getReactionEmote().getName())))
                 return false;
             return isValidUser(event.getUser(), event.getGuild());
         }, event -> {
             int newPageNum = pageNum;
-            switch(event.getReaction().getEmote().getName())
+            switch(event.getReactionEmote().getName())
             {
                 case LEFT:  if(newPageNum>1) newPageNum--; break;
                 case RIGHT: if(newPageNum<pages) newPageNum++; break;

--- a/src/main/java/com/jagrosh/jdautilities/menu/pagination/PaginatorBuilder.java
+++ b/src/main/java/com/jagrosh/jdautilities/menu/pagination/PaginatorBuilder.java
@@ -25,6 +25,10 @@ import com.jagrosh.jdautilities.menu.MenuBuilder;
 import net.dv8tion.jda.core.entities.Message;
 
 /**
+ * Scheduled for reallocation in 2.0
+ *
+ * <p>Full information on these and other 2.0 deprecations and changes can be found
+ * <a href="https://gist.github.com/TheMonitorLizard/4f09ac2a3c9d8019dc3cde02cc456eee">here</a>
  *
  * @author John Grosh
  */

--- a/src/main/java/com/jagrosh/jdautilities/menu/selectiondialog/SelectionDialog.java
+++ b/src/main/java/com/jagrosh/jdautilities/menu/selectiondialog/SelectionDialog.java
@@ -34,6 +34,10 @@ import net.dv8tion.jda.core.exceptions.PermissionException;
 import net.dv8tion.jda.core.requests.RestAction;
 
 /**
+ * Scheduled for reallocation in 2.0
+ *
+ * <p>Full information on these and other 2.0 deprecations and changes can be found
+ * <a href="https://gist.github.com/TheMonitorLizard/4f09ac2a3c9d8019dc3cde02cc456eee">here</a>
  *
  * @author John Grosh
  */

--- a/src/main/java/com/jagrosh/jdautilities/menu/selectiondialog/SelectionDialog.java
+++ b/src/main/java/com/jagrosh/jdautilities/menu/selectiondialog/SelectionDialog.java
@@ -163,15 +163,15 @@ public class SelectionDialog extends Menu {
         waiter.waitForEvent(MessageReactionAddEvent.class, event -> {
             if(!event.getMessageId().equals(message.getId()))
                 return false;
-            if(!(UP.equals(event.getReaction().getEmote().getName()) 
-                    || DOWN.equals(event.getReaction().getEmote().getName())
-                    || CANCEL.equals(event.getReaction().getEmote().getName())
-                    || SELECT.equals(event.getReaction().getEmote().getName())))
+            if(!(UP.equals(event.getReactionEmote().getName())
+                    || DOWN.equals(event.getReactionEmote().getName())
+                    || CANCEL.equals(event.getReactionEmote().getName())
+                    || SELECT.equals(event.getReactionEmote().getName())))
                 return false;
             return isValidUser(event.getUser(), event.getGuild());
         }, event -> {
             int newSelection = selection;
-            switch(event.getReaction().getEmote().getName())
+            switch(event.getReactionEmote().getName())
             {
                 case UP:
                     if(newSelection>1)

--- a/src/main/java/com/jagrosh/jdautilities/menu/selectiondialog/SelectionDialog.java
+++ b/src/main/java/com/jagrosh/jdautilities/menu/selectiondialog/SelectionDialog.java
@@ -19,6 +19,7 @@ import java.awt.Color;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import com.jagrosh.jdautilities.menu.Menu;
@@ -49,8 +50,8 @@ public class SelectionDialog extends Menu {
     private final Function<Integer,Color> color;
     private final boolean loop;
     private final Function<Integer,String> text;
-    private final Consumer<Integer> success;
-    private final Runnable cancel;
+    private final BiConsumer<Message, Integer> success;
+    private final Consumer<Message> cancel;
     
     public static final String UP = "\uD83D\uDD3C";
     public static final String DOWN = "\uD83D\uDD3D";
@@ -59,7 +60,7 @@ public class SelectionDialog extends Menu {
     
     protected SelectionDialog(EventWaiter waiter, Set<User> users, Set<Role> roles, long timeout, TimeUnit unit,
             List<String> choices, String leftEnd, String rightEnd, String defaultLeft, String defaultRight, 
-            Function<Integer,Color> color, boolean loop, Consumer<Integer> success, Runnable cancel, Function<Integer,String> text)
+            Function<Integer,Color> color, boolean loop, BiConsumer<Message, Integer> success, Consumer<Message> cancel, Function<Integer,String> text)
     {
         super(waiter, users, roles, timeout, unit);
         this.choices = choices;
@@ -167,7 +168,7 @@ public class SelectionDialog extends Menu {
                     || CANCEL.equals(event.getReaction().getEmote().getName())
                     || SELECT.equals(event.getReaction().getEmote().getName())))
                 return false;
-            return isValidUser(event);
+            return isValidUser(event.getUser(), event.getGuild());
         }, event -> {
             int newSelection = selection;
             switch(event.getReaction().getEmote().getName())
@@ -185,12 +186,14 @@ public class SelectionDialog extends Menu {
                         newSelection = 1;
                     break;
                 case CANCEL:
+                    // Temporary readjustment to support function while maintaining the delete
+                    cancel.accept(message);
                     message.delete().queue();
-                    cancel.run();
                     return;
                 case SELECT:
+                    // Temporary readjustment to support function while maintaining the delete
+                    success.accept(message, selection);
                     message.delete().queue();
-                    success.accept(selection);
                     return;
             }
             try{event.getReaction().removeReaction(event.getUser()).queue();}catch(PermissionException e){}
@@ -198,7 +201,10 @@ public class SelectionDialog extends Menu {
             message.editMessage(render(n)).queue(m -> {
                 selectionDialog(m, n);
             });
-        }, timeout, unit, () -> {message.delete().queue(); cancel.run();});
+        }, timeout, unit, () -> {
+            cancel.accept(message);
+            message.delete().queue();
+        });
     }
     
     private Message render(int selection)

--- a/src/main/java/com/jagrosh/jdautilities/menu/selectiondialog/SelectionDialogBuilder.java
+++ b/src/main/java/com/jagrosh/jdautilities/menu/selectiondialog/SelectionDialogBuilder.java
@@ -24,6 +24,10 @@ import java.util.function.Function;
 import com.jagrosh.jdautilities.menu.MenuBuilder;
 
 /**
+ * Scheduled for reallocation in 2.0
+ *
+ * <p>Full information on these and other 2.0 deprecations and changes can be found
+ * <a href="https://gist.github.com/TheMonitorLizard/4f09ac2a3c9d8019dc3cde02cc456eee">here</a>
  *
  * @author John Grosh
  */

--- a/src/main/java/com/jagrosh/jdautilities/menu/slideshow/Slideshow.java
+++ b/src/main/java/com/jagrosh/jdautilities/menu/slideshow/Slideshow.java
@@ -162,7 +162,7 @@ public class Slideshow extends Menu {
                     || STOP.equals(event.getReaction().getEmote().getName())
                     || RIGHT.equals(event.getReaction().getEmote().getName())))
                 return false;
-            return isValidUser(event);
+            return isValidUser(event.getUser(), event.getGuild());
         }, event -> {
             int newPageNum = pageNum;
             switch(event.getReaction().getEmote().getName())

--- a/src/main/java/com/jagrosh/jdautilities/menu/slideshow/Slideshow.java
+++ b/src/main/java/com/jagrosh/jdautilities/menu/slideshow/Slideshow.java
@@ -34,6 +34,10 @@ import net.dv8tion.jda.core.exceptions.PermissionException;
 import net.dv8tion.jda.core.requests.RestAction;
 
 /**
+ * Scheduled for reallocation in 2.0
+ *
+ * <p>Full information on these and other 2.0 deprecations and changes can be found
+ * <a href="https://gist.github.com/TheMonitorLizard/4f09ac2a3c9d8019dc3cde02cc456eee">here</a>
  *
  * @author John Grosh
  */

--- a/src/main/java/com/jagrosh/jdautilities/menu/slideshow/Slideshow.java
+++ b/src/main/java/com/jagrosh/jdautilities/menu/slideshow/Slideshow.java
@@ -158,14 +158,14 @@ public class Slideshow extends Menu {
         waiter.waitForEvent(MessageReactionAddEvent.class, (MessageReactionAddEvent event) -> {
             if(!event.getMessageId().equals(message.getId()))
                 return false;
-            if(!(LEFT.equals(event.getReaction().getEmote().getName()) 
-                    || STOP.equals(event.getReaction().getEmote().getName())
-                    || RIGHT.equals(event.getReaction().getEmote().getName())))
+            if(!(LEFT.equals(event.getReactionEmote().getName())
+                    || STOP.equals(event.getReactionEmote().getName())
+                    || RIGHT.equals(event.getReactionEmote().getName())))
                 return false;
             return isValidUser(event.getUser(), event.getGuild());
         }, event -> {
             int newPageNum = pageNum;
-            switch(event.getReaction().getEmote().getName())
+            switch(event.getReactionEmote().getName())
             {
                 case LEFT:  if(newPageNum>1) newPageNum--; break;
                 case RIGHT: if(newPageNum<urls.size()) newPageNum++; break;

--- a/src/main/java/com/jagrosh/jdautilities/menu/slideshow/SlideshowBuilder.java
+++ b/src/main/java/com/jagrosh/jdautilities/menu/slideshow/SlideshowBuilder.java
@@ -26,6 +26,10 @@ import com.jagrosh.jdautilities.menu.MenuBuilder;
 import net.dv8tion.jda.core.entities.Message;
 
 /**
+ * Scheduled for reallocation in 2.0
+ *
+ * <p>Full information on these and other 2.0 deprecations and changes can be found
+ * <a href="https://gist.github.com/TheMonitorLizard/4f09ac2a3c9d8019dc3cde02cc456eee">here</a>
  *
  * @author John Grosh
  */

--- a/src/main/java/com/jagrosh/jdautilities/package-info.java
+++ b/src/main/java/com/jagrosh/jdautilities/package-info.java
@@ -15,7 +15,7 @@
  */
 
 /**
- * <p>Base package for the entirety of this extension library! From here you can navigate to one of the child packages inside.
+ * Base package for the entirety of this extension library! From here you can navigate to one of the child packages inside.
  * 
  * <p>The contents of this package are summarized as follows:
  * <ul>

--- a/src/main/java/com/jagrosh/jdautilities/utils/FinderUtil.java
+++ b/src/main/java/com/jagrosh/jdautilities/utils/FinderUtil.java
@@ -17,26 +17,25 @@ package com.jagrosh.jdautilities.utils;
 
 import net.dv8tion.jda.core.JDA;
 import net.dv8tion.jda.core.entities.*;
+import net.dv8tion.jda.core.utils.cache.SnowflakeCacheView;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
- * A series of query based utilities for finding entities, either globally across all accessible {@link
- * net.dv8tion.jda.core.entities.Guild Guild}s, or locally to a specified Guild.
+ * A series of query based utilities for finding entities, either globally across all accessible
+ * {@link net.dv8tion.jda.core.entities.Guild Guild}s, or locally to a specified Guild.
  *
- * <p>All methods use a similar priority hierarchy and return a {@link java.util.List List} based on the results.
+ * <p>All methods use a similar priority hierarchy and return an immutable {@link java.util.List List} based on the results.
  * <br>The hierarchy is as follows:
  * <ul>
  *     <li>Special Cases: Specifics of these are described per individual method documentation.
- *     <br>Note that successful results from these are typically {@link java.util.Collections#singletonList(Object)
- *     a singleton list}.</li>
- *     <li>Direct ID: Query is a number with 17 or more digits, resembling an {@link net.dv8tion.jda.core.entities.ISnowflake
- *     ISnowflake} ID.</li>
+ *     <br>Note that successful results from these are typically
+ *     {@link java.util.Collections#singletonList(Object) a singleton list}.</li>
+ *     <li>Direct ID: Query is a number with 17 or more digits, resembling an
+ *     {@link net.dv8tion.jda.core.entities.ISnowflake Snowflake} ID.</li>
  *     <li>Exact Match: Query provided is an exact match (case sensitive and complete) to one or more entities.</li>
  *     <li>Wrong Case: Query provided is a case-insensitive, but exact, match to the entirety of one or more entities.</li>
  *     <li>Starting With: Query provided is an case-insensitive match to the beginning of one or more entities.</li>
@@ -46,20 +45,22 @@ import java.util.stream.Collectors;
  * kind of results (IE: the "exact" list will never contain any results from a successful "starting with" match,
  * unless by chance they could technically be the same result).
  *
- * <p>All of these utilities were inspired by and ported to JDA 3.X from
+ * <p>Many of these utilities were inspired by and ported to JDA 3.X from
  * <a href="https://github.com/jagrosh/Spectra/blob/master/src/spectra/utils/FinderUtil.java">Spectra's FinderUtil</a>
  * originally written by <a href="https://github.com/jagrosh/">jagrosh</a> in 2.X.
  *
  * @since  1.3
  * @author Kaidan Gustave
  */
+@SuppressWarnings("Duplicates")
 public class FinderUtil
 {
-    private final static Pattern DISCORD_ID = Pattern.compile("\\d{17,20}"); // ID
-    private final static Pattern FULL_USER_REF = Pattern.compile("(.{2,32})\\s*#(\\d{4})"); // $1 -> username, $2 -> discriminator
-    private final static Pattern USER_MENTION = Pattern.compile("<@!?(\\d{17,20})>"); // $1 -> ID
-    private final static Pattern CHANNEL_MENTION = Pattern.compile("<#(\\d{17,20})>"); // $1 -> ID
-    private final static Pattern ROLE_MENTION = Pattern.compile("<@&(\\d{17,20})>"); // $1 -> ID
+    public final static Pattern DISCORD_ID = Pattern.compile("\\d{17,20}"); // ID
+    public final static Pattern FULL_USER_REF = Pattern.compile("(.{2,32})\\s*#(\\d{4})"); // $1 -> username, $2 -> discriminator
+    public final static Pattern USER_MENTION = Pattern.compile("<@!?(\\d{17,20})>"); // $1 -> ID
+    public final static Pattern CHANNEL_MENTION = Pattern.compile("<#(\\d{17,20})>"); // $1 -> ID
+    public final static Pattern ROLE_MENTION = Pattern.compile("<@&(\\d{17,20})>"); // $1 -> ID
+    public final static Pattern EMOTE_MENTION = Pattern.compile("<:(.{2,32}):(\\d{17,20})>");
 
     /**
      * Queries a provided instance of {@link net.dv8tion.jda.core.JDA JDA} for {@link net.dv8tion.jda.core.entities.User User}s.
@@ -92,7 +93,7 @@ public class FinderUtil
         {
             String lowerName = fullRefMatch.group(1).toLowerCase();
             String discrim = fullRefMatch.group(2);
-            List<User> users = jda.getUsers().stream()
+            List<User> users = jda.getUserCache().stream()
                     .filter(user -> user.getName().toLowerCase().equals(lowerName)
                             && user.getDiscriminator().equals(discrim))
                     .collect(Collectors.toList());
@@ -110,7 +111,7 @@ public class FinderUtil
         ArrayList<User> startswith = new ArrayList<>();
         ArrayList<User> contains = new ArrayList<>();
         String lowerquery = query.toLowerCase();
-        jda.getUsers().forEach(user -> {
+        jda.getUserCache().forEach(user -> {
             String name = user.getName();
             if(name.equals(query))
                 exact.add(user);
@@ -122,12 +123,12 @@ public class FinderUtil
                 contains.add(user);
         });
         if(!exact.isEmpty())
-            return exact;
+            return Collections.unmodifiableList(exact);
         if(!wrongcase.isEmpty())
-            return wrongcase;
+            return Collections.unmodifiableList(wrongcase);
         if(!startswith.isEmpty())
-            return startswith;
-        return contains;
+            return Collections.unmodifiableList(startswith);
+        return Collections.unmodifiableList(contains);
     }
 
     /**
@@ -212,20 +213,20 @@ public class FinderUtil
 
             if(u.getName().equals(query))
                 exact.add(u);
-            else if (exact.isEmpty() && u.getName().equalsIgnoreCase(query))
+            else if(exact.isEmpty() && u.getName().equalsIgnoreCase(query))
                 wrongcase.add(u);
-            else if (wrongcase.isEmpty() && u.getName().toLowerCase().startsWith(lowerQuery))
+            else if(wrongcase.isEmpty() && u.getName().toLowerCase().startsWith(lowerQuery))
                 startswith.add(u);
-            else if (startswith.isEmpty() && u.getName().toLowerCase().contains(lowerQuery))
+            else if(startswith.isEmpty() && u.getName().toLowerCase().contains(lowerQuery))
                 contains.add(u);
         }
         if(!exact.isEmpty())
-            return exact;
+            return Collections.unmodifiableList(exact);
         if(!wrongcase.isEmpty())
-            return wrongcase;
+            return Collections.unmodifiableList(wrongcase);
         if(!startswith.isEmpty())
-            return startswith;
-        return contains;
+            return Collections.unmodifiableList(startswith);
+        return Collections.unmodifiableList(contains);
     }
 
     /**
@@ -269,7 +270,7 @@ public class FinderUtil
         {
             String lowerName = fullRefMatch.group(1).toLowerCase();
             String discrim = fullRefMatch.group(2);
-            List<Member> members = guild.getMembers().stream()
+            List<Member> members = guild.getMemberCache().stream()
                     .filter(member -> member.getUser().getName().toLowerCase().equals(lowerName)
                             && member.getUser().getDiscriminator().equals(discrim))
                     .collect(Collectors.toList());
@@ -287,25 +288,25 @@ public class FinderUtil
         ArrayList<Member> startswith = new ArrayList<>();
         ArrayList<Member> contains = new ArrayList<>();
         String lowerquery = query.toLowerCase();
-        guild.getMembers().forEach(member -> {
+        guild.getMemberCache().forEach(member -> {
             String name = member.getUser().getName();
             String effName = member.getEffectiveName();
             if(name.equals(query) || effName.equals(query))
                 exact.add(member);
-            else if ((name.equalsIgnoreCase(query) || effName.equalsIgnoreCase(query)) && exact.isEmpty())
+            else if((name.equalsIgnoreCase(query) || effName.equalsIgnoreCase(query)) && exact.isEmpty())
                 wrongcase.add(member);
-            else if ((name.toLowerCase().startsWith(lowerquery) || effName.toLowerCase().startsWith(lowerquery)) && wrongcase.isEmpty())
+            else if((name.toLowerCase().startsWith(lowerquery) || effName.toLowerCase().startsWith(lowerquery)) && wrongcase.isEmpty())
                 startswith.add(member);
-            else if ((name.toLowerCase().contains(lowerquery) || effName.toLowerCase().contains(lowerquery)) && startswith.isEmpty())
+            else if((name.toLowerCase().contains(lowerquery) || effName.toLowerCase().contains(lowerquery)) && startswith.isEmpty())
                 contains.add(member);
         });
         if(!exact.isEmpty())
-            return exact;
+            return Collections.unmodifiableList(exact);
         if(!wrongcase.isEmpty())
-            return wrongcase;
+            return Collections.unmodifiableList(wrongcase);
         if(!startswith.isEmpty())
-            return startswith;
-        return contains;
+            return Collections.unmodifiableList(startswith);
+        return Collections.unmodifiableList(contains);
     }
 
     /**
@@ -339,29 +340,8 @@ public class FinderUtil
             if(tc!=null)
                 return Collections.singletonList(tc);
         }
-        ArrayList<TextChannel> exact = new ArrayList<>();
-        ArrayList<TextChannel> wrongcase = new ArrayList<>();
-        ArrayList<TextChannel> startswith = new ArrayList<>();
-        ArrayList<TextChannel> contains = new ArrayList<>();
-        String lowerquery = query.toLowerCase();
-        jda.getTextChannels().forEach((tc) -> {
-            String name = tc.getName();
-            if(name.equals(query))
-                exact.add(tc);
-            else if (name.equalsIgnoreCase(query) && exact.isEmpty())
-                wrongcase.add(tc);
-            else if (name.toLowerCase().startsWith(lowerquery) && wrongcase.isEmpty())
-                startswith.add(tc);
-            else if (name.toLowerCase().contains(lowerquery) && startswith.isEmpty())
-                contains.add(tc);
-        });
-        if(!exact.isEmpty())
-            return exact;
-        if(!wrongcase.isEmpty())
-            return wrongcase;
-        if(!startswith.isEmpty())
-            return startswith;
-        return contains;
+
+        return genericTextChannelSearch(query, jda.getTextChannelCache());
     }
 
     /**
@@ -395,29 +375,36 @@ public class FinderUtil
             if(tc!=null)
                 return Collections.singletonList(tc);
         }
+
+        return genericTextChannelSearch(query, guild.getTextChannelCache());
+    }
+
+    // Generic search for findTextChannels methods
+    private static List<TextChannel> genericTextChannelSearch(String query, SnowflakeCacheView<TextChannel> cache)
+    {
         ArrayList<TextChannel> exact = new ArrayList<>();
         ArrayList<TextChannel> wrongcase = new ArrayList<>();
         ArrayList<TextChannel> startswith = new ArrayList<>();
         ArrayList<TextChannel> contains = new ArrayList<>();
         String lowerquery = query.toLowerCase();
-        guild.getTextChannels().forEach((tc) -> {
+        cache.forEach((tc) -> {
             String name = tc.getName();
             if(name.equals(query))
                 exact.add(tc);
-            else if (name.equalsIgnoreCase(query) && exact.isEmpty())
+            else if(name.equalsIgnoreCase(query) && exact.isEmpty())
                 wrongcase.add(tc);
-            else if (name.toLowerCase().startsWith(lowerquery) && wrongcase.isEmpty())
+            else if(name.toLowerCase().startsWith(lowerquery) && wrongcase.isEmpty())
                 startswith.add(tc);
-            else if (name.toLowerCase().contains(lowerquery) && startswith.isEmpty())
+            else if(name.toLowerCase().contains(lowerquery) && startswith.isEmpty())
                 contains.add(tc);
         });
         if(!exact.isEmpty())
-            return exact;
+            return Collections.unmodifiableList(exact);
         if(!wrongcase.isEmpty())
-            return wrongcase;
+            return Collections.unmodifiableList(wrongcase);
         if(!startswith.isEmpty())
-            return startswith;
-        return contains;
+            return Collections.unmodifiableList(startswith);
+        return Collections.unmodifiableList(contains);
     }
 
     /**
@@ -441,29 +428,7 @@ public class FinderUtil
             if(vc!=null)
                 return Collections.singletonList(vc);
         }
-        ArrayList<VoiceChannel> exact = new ArrayList<>();
-        ArrayList<VoiceChannel> wrongcase = new ArrayList<>();
-        ArrayList<VoiceChannel> startswith = new ArrayList<>();
-        ArrayList<VoiceChannel> contains = new ArrayList<>();
-        String lowerquery = query.toLowerCase();
-        jda.getVoiceChannels().forEach((vc) -> {
-            String name = vc.getName();
-            if(name.equals(query))
-                exact.add(vc);
-            else if (name.equalsIgnoreCase(query) && exact.isEmpty())
-                wrongcase.add(vc);
-            else if (name.toLowerCase().startsWith(lowerquery) && wrongcase.isEmpty())
-                startswith.add(vc);
-            else if (name.toLowerCase().contains(lowerquery) && startswith.isEmpty())
-                contains.add(vc);
-        });
-        if(!exact.isEmpty())
-            return exact;
-        if(!wrongcase.isEmpty())
-            return wrongcase;
-        if(!startswith.isEmpty())
-            return startswith;
-        return contains;
+        return genericVoiceChannelSearch(query, jda.getVoiceChannelCache());
     }
 
     /**
@@ -487,35 +452,119 @@ public class FinderUtil
             if(vc!=null)
                 return Collections.singletonList(vc);
         }
+        return genericVoiceChannelSearch(query, guild.getVoiceChannelCache());
+    }
+
+    // Generic search for findVoiceChannels methods
+    private static List<VoiceChannel> genericVoiceChannelSearch(String query, SnowflakeCacheView<VoiceChannel> cache)
+    {
         ArrayList<VoiceChannel> exact = new ArrayList<>();
         ArrayList<VoiceChannel> wrongcase = new ArrayList<>();
         ArrayList<VoiceChannel> startswith = new ArrayList<>();
         ArrayList<VoiceChannel> contains = new ArrayList<>();
         String lowerquery = query.toLowerCase();
-        guild.getVoiceChannels().forEach((vc) -> {
+        cache.forEach((vc) -> {
             String name = vc.getName();
             if(name.equals(query))
                 exact.add(vc);
-            else if (name.equalsIgnoreCase(query) && exact.isEmpty())
+            else if(name.equalsIgnoreCase(query) && exact.isEmpty())
                 wrongcase.add(vc);
-            else if (name.toLowerCase().startsWith(lowerquery) && wrongcase.isEmpty())
+            else if(name.toLowerCase().startsWith(lowerquery) && wrongcase.isEmpty())
                 startswith.add(vc);
-            else if (name.toLowerCase().contains(lowerquery) && startswith.isEmpty())
+            else if(name.toLowerCase().contains(lowerquery) && startswith.isEmpty())
                 contains.add(vc);
         });
         if(!exact.isEmpty())
-            return exact;
+            return Collections.unmodifiableList(exact);
         if(!wrongcase.isEmpty())
-            return wrongcase;
+            return Collections.unmodifiableList(wrongcase);
         if(!startswith.isEmpty())
-            return startswith;
-        return contains;
+            return Collections.unmodifiableList(startswith);
+        return Collections.unmodifiableList(contains);
+    }
+
+    /**
+     * Queries a provided instance of {@link net.dv8tion.jda.core.JDA JDA} for
+     * {@link net.dv8tion.jda.core.entities.Category Categories}.
+     *
+     * <p>The standard search does not follow any special cases.
+     *
+     * @param  query
+     *         The String query to search by
+     * @param  jda
+     *         The instance of JDA to search from
+     *
+     * @return A possibly-empty {@link java.util.List List} of Categories found by the query from the provided JDA instance.
+     */
+    public static List<Category> findCategories(String query, JDA jda)
+    {
+        if(DISCORD_ID.matcher(query).matches())
+        {
+            Category cat = jda.getCategoryById(query);
+            if(cat != null)
+                return Collections.singletonList(cat);
+        }
+
+        return genericCategorySearch(query, jda.getCategoryCache());
+    }
+
+    /**
+     * Queries a provided {@link net.dv8tion.jda.core.entities.Guild Guild} for
+     * {@link net.dv8tion.jda.core.entities.Category Categories}.
+     *
+     * <p>The standard search does not follow any special cases.
+     *
+     * @param  query
+     *         The String query to search by
+     * @param  guild
+     *         The Guild to search from
+     *
+     * @return A possibly-empty {@link java.util.List List} of Categories found by the query from the provided Guild.
+     */
+    public static List<Category> findCategories(String query, Guild guild)
+    {
+        if(DISCORD_ID.matcher(query).matches())
+        {
+            Category cat = guild.getCategoryById(query);
+            if(cat != null)
+                return Collections.singletonList(cat);
+        }
+
+        return genericCategorySearch(query, guild.getCategoryCache());
+    }
+
+    // Generic search for findCategories methods
+    private static List<Category> genericCategorySearch(String query, SnowflakeCacheView<Category> cache)
+    {
+        ArrayList<Category> exact = new ArrayList<>();
+        ArrayList<Category> wrongcase = new ArrayList<>();
+        ArrayList<Category> startswith = new ArrayList<>();
+        ArrayList<Category> contains = new ArrayList<>();
+        String lowerquery = query.toLowerCase();
+        cache.forEach(cat -> {
+            String name = cat.getName();
+            if(name.equals(query))
+                exact.add(cat);
+            else if(name.equalsIgnoreCase(query) && exact.isEmpty())
+                wrongcase.add(cat);
+            else if(name.toLowerCase().startsWith(lowerquery) && wrongcase.isEmpty())
+                startswith.add(cat);
+            else if(name.toLowerCase().contains(lowerquery) && startswith.isEmpty())
+                contains.add(cat);
+        });
+        if(!exact.isEmpty())
+            return Collections.unmodifiableList(exact);
+        if(!wrongcase.isEmpty())
+            return Collections.unmodifiableList(wrongcase);
+        if(!startswith.isEmpty())
+            return Collections.unmodifiableList(startswith);
+        return Collections.unmodifiableList(contains);
     }
 
     /**
      * Queries a provided {@link net.dv8tion.jda.core.entities.Guild Guild} for {@link net.dv8tion.jda.core.entities.Role Role}s.
      *
-     * <p>The following special case is applied in order of listing before the standard search is done:
+     * <p>The following special case is applied before the standard search is done:
      * <ul>
      *     <li>Role Mention: Query provided matches a @role mention (more specifically {@literal <@&roleID>})</li>
      * </ul>
@@ -533,7 +582,7 @@ public class FinderUtil
         if(roleMention.matches())
         {
             Role role = guild.getRoleById(roleMention.group(1));
-            if(role!=null)
+            if(role!=null && role.isMentionable())
                 return Collections.singletonList(role);
         }
         else if(DISCORD_ID.matcher(query).matches())
@@ -547,10 +596,7 @@ public class FinderUtil
         ArrayList<Role> startswith = new ArrayList<>();
         ArrayList<Role> contains = new ArrayList<>();
         String lowerquery = query.toLowerCase();
-        List<Role> guildRoles = new ArrayList<>();
-        guildRoles.addAll(guild.getRoles());
-        guildRoles.add(guild.getPublicRole());
-        guildRoles.forEach((role) -> {
+        guild.getRoleCache().forEach((role) -> {
             String name = role.getName();
             if(name.equals(query))
                 exact.add(role);
@@ -562,12 +608,120 @@ public class FinderUtil
                 contains.add(role);
         });
         if(!exact.isEmpty())
-            return exact;
+            return Collections.unmodifiableList(exact);
         if(!wrongcase.isEmpty())
-            return wrongcase;
+            return Collections.unmodifiableList(wrongcase);
         if(!startswith.isEmpty())
-            return startswith;
-        return contains;
+            return Collections.unmodifiableList(startswith);
+        return Collections.unmodifiableList(contains);
+    }
+
+    /**
+     * Queries a provided instance of {@link net.dv8tion.jda.core.JDA JDA} for
+     * {@link net.dv8tion.jda.core.entities.Emote Emote}s.
+     *
+     * <p>The following special case is applied before the standard search is done:
+     * <ul>
+     *     <li>Emote Mention: Query provided matches a :emote: mention (more specifically {@literal <:emoteName:emoteID>}).
+     *     <br>Note: This only returns here if the emote is <b>valid</b>. Validity being the ID retrieves a non-null
+     *     Emote and that the {@link net.dv8tion.jda.core.entities.Emote#getName() name} of the Emote is equal to the
+     *     name found in the query.</li>
+     * </ul>
+     *
+     * @param  query
+     *         The String query to search by
+     * @param  jda
+     *         The instance of JDA to search from
+     *
+     * @return A possibly-empty {@link java.util.List List} of Emotes found by the query from the provided Guild.
+     */
+    public static List<Emote> findEmotes(String query, JDA jda)
+    {
+        Matcher mentionMatcher = EMOTE_MENTION.matcher(query);
+        if(DISCORD_ID.matcher(query).matches())
+        {
+            Emote emote = jda.getEmoteById(query);
+            if(emote != null)
+                return Collections.singletonList(emote);
+        }
+        else if(mentionMatcher.matches())
+        {
+            String emoteName = mentionMatcher.group(1);
+            String emoteId = mentionMatcher.group(2);
+            Emote emote = jda.getEmoteById(emoteId);
+            if(emote != null && emote.getName().equals(emoteName))
+                return Collections.singletonList(emote);
+        }
+
+        return genericEmoteSearch(query, jda.getEmoteCache());
+    }
+
+    /**
+     * Queries a provided {@link net.dv8tion.jda.core.entities.Guild Guild} for
+     * {@link net.dv8tion.jda.core.entities.Emote Emote}s.
+     *
+     * <p>The following special case is applied before the standard search is done:
+     * <ul>
+     *     <li>Emote Mention: Query provided matches a :emote: mention (more specifically {@literal <:emoteName:emoteID>}).
+     *     <br>Note: This only returns here if the emote is <b>valid</b>. Validity being the ID retrieves a non-null
+     *     Emote and that the {@link net.dv8tion.jda.core.entities.Emote#getName() name} of the Emote is equal to the
+     *     name found in the query.</li>
+     * </ul>
+     *
+     * @param  query
+     *         The String query to search by
+     * @param  guild
+     *         The Guild to search from
+     *
+     * @return A possibly-empty {@link java.util.List List} of Emotes found by the query from the provided Guild.
+     */
+    public static List<Emote> findEmotes(String query, Guild guild)
+    {
+        Matcher mentionMatcher = EMOTE_MENTION.matcher(query);
+        if(DISCORD_ID.matcher(query).matches())
+        {
+            Emote emote = guild.getEmoteById(query);
+            if(emote != null)
+                return Collections.singletonList(emote);
+        }
+        else if(mentionMatcher.matches())
+        {
+            String emoteName = mentionMatcher.group(1);
+            String emoteId = mentionMatcher.group(2);
+            Emote emote = guild.getEmoteById(emoteId);
+            if(emote != null && emote.getName().equals(emoteName))
+                return Collections.singletonList(emote);
+        }
+
+        return genericEmoteSearch(query, guild.getEmoteCache());
+    }
+
+    // Generic search for findEmotes methods
+    private static List<Emote> genericEmoteSearch(String query, SnowflakeCacheView<Emote> cache)
+    {
+        ArrayList<Emote> exact = new ArrayList<>();
+        ArrayList<Emote> wrongcase = new ArrayList<>();
+        ArrayList<Emote> startswith = new ArrayList<>();
+        ArrayList<Emote> contains = new ArrayList<>();
+        String lowerquery = query.toLowerCase();
+        cache.forEach(emote -> {
+            String name = emote.getName();
+            if(name.equals(query))
+                exact.add(emote);
+            else if(name.equalsIgnoreCase(query) && exact.isEmpty())
+                wrongcase.add(emote);
+            else if(name.toLowerCase().startsWith(lowerquery) && wrongcase.isEmpty())
+                startswith.add(emote);
+            else if(name.toLowerCase().contains(lowerquery) && startswith.isEmpty())
+                contains.add(emote);
+        });
+        if(!exact.isEmpty())
+            return Collections.unmodifiableList(exact);
+        if(!wrongcase.isEmpty())
+            return Collections.unmodifiableList(wrongcase);
+        if(!startswith.isEmpty())
+            return Collections.unmodifiableList(startswith);
+        return Collections.unmodifiableList(contains);
     }
 
     // Prevent instantiation

--- a/src/main/java/com/jagrosh/jdautilities/utils/FinderUtil.java
+++ b/src/main/java/com/jagrosh/jdautilities/utils/FinderUtil.java
@@ -56,7 +56,7 @@ import java.util.stream.Collectors;
 public class FinderUtil
 {
     public final static Pattern DISCORD_ID = Pattern.compile("\\d{17,20}"); // ID
-    public final static Pattern FULL_USER_REF = Pattern.compile("(.{2,32})\\s*#(\\d{4})"); // $1 -> username, $2 -> discriminator
+    public final static Pattern FULL_USER_REF = Pattern.compile("(\\S.{0,30}\\S)\\s*#(\\d{4})"); // $1 -> username, $2 -> discriminator
     public final static Pattern USER_MENTION = Pattern.compile("<@!?(\\d{17,20})>"); // $1 -> ID
     public final static Pattern CHANNEL_MENTION = Pattern.compile("<#(\\d{17,20})>"); // $1 -> ID
     public final static Pattern ROLE_MENTION = Pattern.compile("<@&(\\d{17,20})>"); // $1 -> ID

--- a/src/main/java/com/jagrosh/jdautilities/utils/FinderUtil.java
+++ b/src/main/java/com/jagrosh/jdautilities/utils/FinderUtil.java
@@ -192,7 +192,7 @@ public class FinderUtil
      *     <br><b>NOTE:</b> this can return a list with more than one entity.</li>
      * </ul>
      *
-     * <h4>WARNING</h4>
+     * <b>WARNING</b>
      *
      * Unlike the other finder methods, this one has two very unique features that set it apart from the rest:
      * <ul>


### PR DESCRIPTION
This version adds some tweaks to behavior with the new features and changes from `feature/shard-manager` and `experimental/message-rw`, primarily with regards to `FinderUtil`.

FinderUtil now contains a set of two methods per entity search for methods that take an instance of `JDA` as a parameter:
1) `findX` which will search for entities via query across ShardManager if the bot is sharded, otherwise it will search simply across the JDA instance as it always has.
2) `findShardX` immediately skips to query from the instance of `JDA`, regardless of whether or not the bot has a ShardManager or is even sharded.

Note: none of these methods assume or rely on the bot being sharded to work correctly. For example, if you were to call `FinderUtil.findShardUsers(String, JDA)` where `JDA` is an unsharded bot, it wouldn't cause any issues or alternate behavior from calling `FinderUtil.findUsers(String, JDA)` under the same context.

Some other additions such as `Command#hidden` are now available as well!

Also good to point out: this version is geared towards staging for deprecations and changes that happen in 2.0.
I have labeled all methods that will be removed in 2.0 with `@Deprecated` tags as best as I could, and I have tried to implement the replacements in this version to the best of my ability, however the functionality of some of these changes is breaking enough to a point where implementing it now would break all compatibility anyways. There's always the chance I missed something, so if I did please feel free to point it out.