### PR TITLE
[Enhancement] Now allow for custom implementations of EventWaiter

### DIFF
--- a/commons/src/main/java/com/jagrosh/jdautilities/commons/waiter/EventWaiter.java
+++ b/commons/src/main/java/com/jagrosh/jdautilities/commons/waiter/EventWaiter.java
@@ -277,13 +277,10 @@ public class EventWaiter implements IEventWaiter, EventListener
         {
             if(waitingEvents.containsKey(c))
             {
-                Set<WaitingEvent> set = waitingEvents.get(c);
-                WaitingEvent[] toRemove = set.toArray(new WaitingEvent[set.size()]);
-
                 // WaitingEvent#attempt invocations that return true have passed their condition tests
                 // and executed the action. We filter the ones that return false out of the toRemove and
                 // remove them all from the set.
-                set.removeAll(Stream.of(toRemove).filter(i -> i.attempt(event)).collect(Collectors.toSet()));
+                waitingEvents.get(c).removeIf(i -> i.attempt(event));
             }
             if(event instanceof ShutdownEvent && shutdownAutomatically)
             {

--- a/commons/src/main/java/com/jagrosh/jdautilities/commons/waiter/IEventWaiter.java
+++ b/commons/src/main/java/com/jagrosh/jdautilities/commons/waiter/IEventWaiter.java
@@ -33,7 +33,7 @@ import java.util.function.Predicate;
  *
  * @see    EventWaiter
  *
- * @since  2.2
+ * @since  2.1
  * @author Kaidan Gustave
  *
  * @implNote

--- a/commons/src/main/java/com/jagrosh/jdautilities/commons/waiter/IEventWaiter.java
+++ b/commons/src/main/java/com/jagrosh/jdautilities/commons/waiter/IEventWaiter.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2016-2018 John Grosh (jagrosh) & Kaidan Gustave (TheMonitorLizard)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jagrosh.jdautilities.commons.waiter;
+
+import net.dv8tion.jda.core.events.Event;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+/**
+ * Implementable frame for waiting on {@link net.dv8tion.jda.core.events.Event Event}s.
+ *
+ * <p>This interface serves to allow custom implementations for interacting with
+ * menus in the {@code menu} module of the JDA-Utilities library, allowing developers
+ * direct access to the precise internal function that handles event responses.
+ *
+ * <p>The standard implementation of this interface is
+ * {@link com.jagrosh.jdautilities.commons.waiter.EventWaiter EventWaiter}.
+ *
+ * @see    EventWaiter
+ *
+ * @since  2.2
+ * @author Kaidan Gustave
+ *
+ * @implNote
+ *         Event tracking and handling is not explicitly required
+ *         when implementing this interface, however anyone looking
+ *         to implement this should have a plan for handling events.
+ *         <br>For instance, those using JDA's default
+ *         {@link net.dv8tion.jda.core.hooks.IEventManager IEventManager}
+ *         should have the implementation of this interface also
+ *         implement {@link net.dv8tion.jda.core.hooks.EventListener EventListener},
+ *         and add it to an instance of JDA as a listener.
+ */
+public interface IEventWaiter
+{
+    /**
+     * Waits an indefinite amount of time for an {@link net.dv8tion.jda.core.events.Event Event} that
+     * returns {@code true} when tested with the provided {@link java.util.function.Predicate Predicate}.
+     *
+     * <p>When this occurs, the provided {@link java.util.function.Consumer Consumer} will accept and
+     * execute using the same Event.
+     *
+     * @param  <T>
+     *         The type of Event to wait for.
+     * @param  classType
+     *         The {@link java.lang.Class} of the Event to wait for. Never null.
+     * @param  condition
+     *         The Predicate to test when Events of the provided type are thrown. Never null.
+     * @param  action
+     *         The Consumer to perform an action when the condition Predicate returns {@code true}. Never null.
+     *
+     * @throws java.lang.IllegalArgumentException
+     *         One of two reasons:
+     *         <ul>
+     *             <li>1) Either the {@code classType}, {@code condition}, or {@code action} was {@code null}.</li>
+     *             <li>2) The internal threadpool is shut down, meaning that no more tasks can be submitted.</li>
+     *         </ul>
+     */
+    default <T extends Event> void waitForEvent(Class<T> classType, Predicate<T> condition, Consumer<T> action)
+    {
+        // Do not override this!
+        // This method is only here for backwards compatibility with the menu module!
+        waitForEvent(classType, condition, action, -1, null, null);
+    }
+
+    /**
+     * Waits a predetermined amount of time for an {@link net.dv8tion.jda.core.events.Event Event} that
+     * returns {@code true} when tested with the provided {@link java.util.function.Predicate Predicate}.
+     *
+     * <p>Once started, there are two possible outcomes:
+     * <ul>
+     *     <li>The correct Event occurs within the time allotted, and the provided
+     *     {@link java.util.function.Consumer Consumer} will accept and execute using the same Event.</li>
+     *
+     *     <li>The time limit is elapsed and the provided {@link java.lang.Runnable} is executed.</li>
+     * </ul>
+     *
+     * @param  <T>
+     *         The type of Event to wait for.
+     * @param  classType
+     *         The {@link java.lang.Class} of the Event to wait for. Never null.
+     * @param  condition
+     *         The Predicate to test when Events of the provided type are thrown. Never null.
+     * @param  action
+     *         The Consumer to perform an action when the condition Predicate returns {@code true}. Never null.
+     * @param  timeout
+     *         The maximum amount of time to wait for, or {@code -1} if there is no timeout.
+     * @param  unit
+     *         The {@link java.util.concurrent.TimeUnit TimeUnit} measurement of the timeout, or
+     *         {@code null} if there is no timeout.
+     * @param  timeoutAction
+     *         The Runnable to run if the time runs out before a correct Event is thrown, or
+     *         {@code null} if there is no action on timeout.
+     *
+     * @throws java.lang.IllegalArgumentException
+     *         One of two reasons:
+     *         <ul>
+     *             <li>1) Either the {@code classType}, {@code condition}, or {@code action} was {@code null}.</li>
+     *             <li>2) The internal threadpool is shut down, meaning that no more tasks can be submitted.</li>
+     *         </ul>
+     */
+    <T extends Event> void waitForEvent(Class<T> classType, Predicate<T> condition, Consumer<T> action,
+                                        long timeout, TimeUnit unit, Runnable timeoutAction);
+}

--- a/menu/src/main/java/com/jagrosh/jdautilities/menu/ButtonMenu.java
+++ b/menu/src/main/java/com/jagrosh/jdautilities/menu/ButtonMenu.java
@@ -22,7 +22,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
-import com.jagrosh.jdautilities.commons.waiter.EventWaiter;
+import com.jagrosh.jdautilities.commons.waiter.IEventWaiter;
 import net.dv8tion.jda.core.EmbedBuilder;
 import net.dv8tion.jda.core.MessageBuilder;
 import net.dv8tion.jda.core.entities.Emote;
@@ -51,7 +51,7 @@ public class ButtonMenu extends Menu
     private final Consumer<ReactionEmote> action;
     private final Consumer<Message> finalAction;
     
-    ButtonMenu(EventWaiter waiter, Set<User> users, Set<Role> roles, long timeout, TimeUnit unit,
+    ButtonMenu(IEventWaiter waiter, Set<User> users, Set<Role> roles, long timeout, TimeUnit unit,
                Color color, String text, String description, List<String> choices, Consumer<ReactionEmote> action, Consumer<Message> finalAction)
     {
         super(waiter, users, roles, timeout, unit);
@@ -182,7 +182,7 @@ public class ButtonMenu extends Menu
          * @throws java.lang.IllegalArgumentException
          *         If one of the following is violated:
          *         <ul>
-         *             <li>No {@link com.jagrosh.jdautilities.commons.waiter.EventWaiter EventWaiter} was set.</li>
+         *             <li>No {@link com.jagrosh.jdautilities.commons.waiter.IEventWaiter IEventWaiter} was set.</li>
          *             <li>No choices were set.</li>
          *             <li>No action {@link java.util.function.Consumer Consumer} was set.</li>
          *             <li>Neither text nor description were set.</li>
@@ -191,7 +191,7 @@ public class ButtonMenu extends Menu
         @Override
         public ButtonMenu build()
         {
-            Checks.check(waiter != null, "Must set an EventWaiter");
+            Checks.check(waiter != null, "Must set an IEventWaiter");
             Checks.check(!choices.isEmpty(), "Must have at least one choice");
             Checks.check(action != null, "Must provide an action consumer");
             Checks.check(text != null || description != null, "Either text or description must be set");

--- a/menu/src/main/java/com/jagrosh/jdautilities/menu/Menu.java
+++ b/menu/src/main/java/com/jagrosh/jdautilities/menu/Menu.java
@@ -20,13 +20,13 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
-import com.jagrosh.jdautilities.commons.waiter.EventWaiter;
+import com.jagrosh.jdautilities.commons.waiter.IEventWaiter;
 import net.dv8tion.jda.core.entities.*;
 
 import javax.annotation.Nullable;
 
 /**
- * A frame for wrapping an {@link com.jagrosh.jdautilities.commons.waiter.EventWaiter EventWaiter}
+ * A frame for wrapping an {@link com.jagrosh.jdautilities.commons.waiter.IEventWaiter IEventWaiter}
  * into a "action, reaction" menu that waits on forms of user input such as reactions,
  * or key-phrases.
  *
@@ -43,6 +43,7 @@ import javax.annotation.Nullable;
  * {@link Menu.Builder Menu.Builder} for more info).
  *
  * @see    com.jagrosh.jdautilities.commons.waiter.EventWaiter
+ * @see    com.jagrosh.jdautilities.commons.waiter.IEventWaiter
  * @see    Menu.Builder
  *
  * @author John Grosh
@@ -55,13 +56,13 @@ import javax.annotation.Nullable;
  */
 public abstract class Menu
 {
-    protected final EventWaiter waiter;
+    protected final IEventWaiter waiter;
     protected Set<User> users;
     protected Set<Role> roles;
     protected final long timeout;
     protected final TimeUnit unit;
     
-    protected Menu(EventWaiter waiter, Set<User> users, Set<Role> roles, long timeout, TimeUnit unit)
+    protected Menu(IEventWaiter waiter, Set<User> users, Set<Role> roles, long timeout, TimeUnit unit)
     {
         this.waiter = waiter;
         this.users = users;
@@ -185,7 +186,7 @@ public abstract class Menu
     @SuppressWarnings("unchecked")
     public abstract static class Builder<T extends Builder<T, V>, V extends Menu>
     {
-        protected EventWaiter waiter;
+        protected IEventWaiter waiter;
         protected Set<User> users = new HashSet<>();
         protected Set<Role> roles = new HashSet<>();
         protected long timeout = 1;
@@ -201,18 +202,18 @@ public abstract class Menu
         public abstract V build();
 
         /**
-         * Sets the {@link com.jagrosh.jdautilities.commons.waiter.EventWaiter EventWaiter}
+         * Sets the {@link com.jagrosh.jdautilities.commons.waiter.IEventWaiter IEventWaiter}
          * that will do {@link com.jagrosh.jdautilities.menu.Menu Menu} operations.
          *
-         * <p><b>NOTE:</b> All Menus will only work with an EventWaiter set!
-         * <br>Not setting an EventWaiter means the Menu will not work.
+         * <p><b>NOTE:</b> All Menus will only work with an IEventWaiter set!
+         * <br>Not setting an IEventWaiter means the Menu will not work.
          *
          * @param  waiter
-         *         The EventWaiter
+         *         The IEventWaiter
          *
          * @return This builder
          */
-        public final T setEventWaiter(EventWaiter waiter)
+        public final T setEventWaiter(IEventWaiter waiter)
         {
             this.waiter = waiter;
             return (T) this;

--- a/menu/src/main/java/com/jagrosh/jdautilities/menu/OrderedMenu.java
+++ b/menu/src/main/java/com/jagrosh/jdautilities/menu/OrderedMenu.java
@@ -23,7 +23,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
-import com.jagrosh.jdautilities.commons.waiter.EventWaiter;
+import com.jagrosh.jdautilities.commons.waiter.IEventWaiter;
 import net.dv8tion.jda.core.EmbedBuilder;
 import net.dv8tion.jda.core.MessageBuilder;
 import net.dv8tion.jda.core.Permission;
@@ -72,7 +72,7 @@ public class OrderedMenu extends Menu
 
     public final static String CANCEL = "\u274C";
     
-    OrderedMenu(EventWaiter waiter, Set<User> users, Set<Role> roles, long timeout, TimeUnit unit,
+    OrderedMenu(IEventWaiter waiter, Set<User> users, Set<Role> roles, long timeout, TimeUnit unit,
                 Color color, String text, String description, List<String> choices, BiConsumer<Message,Integer> action,
                 Consumer<Message> cancel, boolean useLetters, boolean allowTypedInput, boolean useCancel)
     {
@@ -364,7 +364,7 @@ public class OrderedMenu extends Menu
          * @throws java.lang.IllegalArgumentException
          *         If one of the following is violated:
          *         <ul>
-         *             <li>No {@link com.jagrosh.jdautilities.commons.waiter.EventWaiter EventWaiter} was set.</li>
+         *             <li>No {@link com.jagrosh.jdautilities.commons.waiter.IEventWaiter IEventWaiter} was set.</li>
          *             <li>No choices were set.</li>
          *             <li>More than ten choices were set.</li>
          *             <li>No action {@link java.util.function.Consumer Consumer} was set.</li>
@@ -374,7 +374,7 @@ public class OrderedMenu extends Menu
         @Override
         public OrderedMenu build()
         {
-            Checks.check(waiter != null, "Must set an EventWaiter");
+            Checks.check(waiter != null, "Must set an IEventWaiter");
             Checks.check(!choices.isEmpty(), "Must have at least one choice");
             Checks.check(choices.size() <= 10, "Must have no more than ten choices");
             Checks.check(selection != null, "Must provide an selection consumer");

--- a/menu/src/main/java/com/jagrosh/jdautilities/menu/Paginator.java
+++ b/menu/src/main/java/com/jagrosh/jdautilities/menu/Paginator.java
@@ -24,7 +24,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 
-import com.jagrosh.jdautilities.commons.waiter.EventWaiter;
+import com.jagrosh.jdautilities.commons.waiter.IEventWaiter;
 import net.dv8tion.jda.core.EmbedBuilder;
 import net.dv8tion.jda.core.MessageBuilder;
 import net.dv8tion.jda.core.entities.Message;
@@ -80,7 +80,7 @@ public class Paginator extends Menu
     public static final String RIGHT = "\u25B6";
     public static final String BIG_RIGHT = "\u23E9";
     
-    Paginator(EventWaiter waiter, Set<User> users, Set<Role> roles, long timeout, TimeUnit unit,
+    Paginator(IEventWaiter waiter, Set<User> users, Set<Role> roles, long timeout, TimeUnit unit,
               BiFunction<Integer,Integer,Color> color, BiFunction<Integer,Integer,String> text,
               Consumer<Message> finalAction, int columns, int itemsPerPage, boolean showPageNumbers,
               boolean numberItems, List<String> items, boolean waitOnSinglePage, int bulkSkipNumber,
@@ -424,14 +424,14 @@ public class Paginator extends Menu
          * @throws java.lang.IllegalArgumentException
          *         If one of the following is violated:
          *         <ul>
-         *             <li>No {@link com.jagrosh.jdautilities.commons.waiter.EventWaiter EventWaiter} was set.</li>
+         *             <li>No {@link com.jagrosh.jdautilities.commons.waiter.IEventWaiter IEventWaiter} was set.</li>
          *             <li>No items were set to paginate.</li>
          *         </ul>
          */
         @Override
         public Paginator build()
         {
-            Checks.check(waiter != null, "Must set an EventWaiter");
+            Checks.check(waiter != null, "Must set an IEventWaiter");
             Checks.check(!strings.isEmpty(), "Must include at least one item to paginate");
 
             return new Paginator(waiter, users, roles, timeout, unit, color, text, finalAction,

--- a/menu/src/main/java/com/jagrosh/jdautilities/menu/SelectionDialog.java
+++ b/menu/src/main/java/com/jagrosh/jdautilities/menu/SelectionDialog.java
@@ -25,7 +25,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-import com.jagrosh.jdautilities.commons.waiter.EventWaiter;
+import com.jagrosh.jdautilities.commons.waiter.IEventWaiter;
 import net.dv8tion.jda.core.EmbedBuilder;
 import net.dv8tion.jda.core.MessageBuilder;
 import net.dv8tion.jda.core.entities.Message;
@@ -60,7 +60,7 @@ public class SelectionDialog extends Menu
     public static final String SELECT = "\u2705";
     public static final String CANCEL = "\u274E";
     
-    SelectionDialog(EventWaiter waiter, Set<User> users, Set<Role> roles, long timeout, TimeUnit unit,
+    SelectionDialog(IEventWaiter waiter, Set<User> users, Set<Role> roles, long timeout, TimeUnit unit,
                     List<String> choices, String leftEnd, String rightEnd, String defaultLeft, String defaultRight,
                     Function<Integer,Color> color, boolean loop, BiConsumer<Message, Integer> success,
                     Consumer<Message> cancel, Function<Integer,String> text)
@@ -252,7 +252,7 @@ public class SelectionDialog extends Menu
          * @throws java.lang.IllegalArgumentException
          *         If one of the following is violated:
          *         <ul>
-         *             <li>No {@link com.jagrosh.jdautilities.commons.waiter.EventWaiter EventWaiter} was set.</li>
+         *             <li>No {@link com.jagrosh.jdautilities.commons.waiter.IEventWaiter IEventWaiter} was set.</li>
          *             <li>No choices were set.</li>
          *             <li>No action {@link java.util.function.Consumer Consumer} was set.</li>
          *         </ul>
@@ -260,7 +260,7 @@ public class SelectionDialog extends Menu
         @Override
         public SelectionDialog build()
         {
-            Checks.check(waiter != null, "Must set an EventWaiter");
+            Checks.check(waiter != null, "Must set an IEventWaiter");
             Checks.check(!choices.isEmpty(), "Must have at least one choice");
             Checks.check(selection != null, "Must provide a selection consumer");
 

--- a/menu/src/main/java/com/jagrosh/jdautilities/menu/Slideshow.java
+++ b/menu/src/main/java/com/jagrosh/jdautilities/menu/Slideshow.java
@@ -24,7 +24,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 
-import com.jagrosh.jdautilities.commons.waiter.EventWaiter;
+import com.jagrosh.jdautilities.commons.waiter.IEventWaiter;
 import net.dv8tion.jda.core.EmbedBuilder;
 import net.dv8tion.jda.core.MessageBuilder;
 import net.dv8tion.jda.core.entities.Message;
@@ -70,7 +70,7 @@ public class Slideshow extends Menu
     public static final String RIGHT = "\u25B6";
     public static final String BIG_RIGHT = "\u23E9";
     
-    Slideshow(EventWaiter waiter, Set<User> users, Set<Role> roles, long timeout, TimeUnit unit,
+    Slideshow(IEventWaiter waiter, Set<User> users, Set<Role> roles, long timeout, TimeUnit unit,
               BiFunction<Integer,Integer,Color> color, BiFunction<Integer,Integer,String> text,
               BiFunction<Integer,Integer,String> description, Consumer<Message> finalAction,
               boolean showPageNumbers, List<String> items, boolean waitOnSinglePage,
@@ -382,14 +382,14 @@ public class Slideshow extends Menu
          * @throws java.lang.IllegalArgumentException
          *         If one of the following is violated:
          *         <ul>
-         *             <li>No {@link com.jagrosh.jdautilities.commons.waiter.EventWaiter EventWaiter} was set.</li>
+         *             <li>No {@link com.jagrosh.jdautilities.commons.waiter.IEventWaiter EventWaiter} was set.</li>
          *             <li>No items were set to paginate.</li>
          *         </ul>
          */
         @Override
         public Slideshow build()
         {
-            Checks.check(waiter != null, "Must set an EventWaiter");
+            Checks.check(waiter != null, "Must set an IEventWaiter");
             Checks.check(!strings.isEmpty(), "Must include at least one item to paginate");
 
             return new Slideshow(

--- a/menu/src/main/java/com/jagrosh/jdautilities/menu/package-info.java
+++ b/menu/src/main/java/com/jagrosh/jdautilities/menu/package-info.java
@@ -40,6 +40,6 @@
  * implementations for usage.
  *
  * <p>Please note that this entire package makes <b>HEAVY</b> usage of the
- * {@link com.jagrosh.jdautilities.commons.waiter.EventWaiter EventWaiter}.
+ * {@link com.jagrosh.jdautilities.commons.waiter.IEventWaiter IEventWaiter}.
  */
 package com.jagrosh.jdautilities.menu;


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing
[pull-request]: https://github.com/JDA-Applications/JDA-Utilities/pulls

## Pull Request

#### Pull Request Checklist
Please follow the following steps before opening this PR.<br>
PRs that do not complete the checklist will be subject to denial for
missing information.

- [X] I have checked the [pull request page][pull-request] for upcoming
      or merged features/bug fixes.
- [X] I have read JDA's [contributing guidelines][contributing].

#### Pull Request Information
Check and fill in the blanks for all that apply:

- [ ] My PR fixes a bug, error, or other issue with the library's codebase.
- [X] My PR is for the `commons` module of the JDA-Utilities library.
- [ ] My PR creates a new module for the JDA-Utilities library: `______`.

#### Description

Due to the recent EventWaiter requests (among them, asynchronous dispatch of `EventListener#onEvent`, concurrent-modification support, and others I am probably missing), there will now be a new interface as part of the `commons` module: `IEventWaiter`

This will allow for developers to have even the tiniest specifications they might desire at their disposal when dealing with the menus in the `menu` module, and other general specifics.

An example implementation in kotlin can be found [here](https://gist.github.com/TheMonitorLizard/c697171414b274844174f6a1bf1b2086).

Please note that if you currently use `EventWaiter` this PR is 100% backwards compatible, and you should have no codebase changes required upon the release of next version.