### PR TITLE
[Bug] Use optString instead of getString for icon

### DIFF
--- a/oauth2/src/main/java/com/jagrosh/jdautilities/oauth2/entities/impl/OAuth2ClientImpl.java
+++ b/oauth2/src/main/java/com/jagrosh/jdautilities/oauth2/entities/impl/OAuth2ClientImpl.java
@@ -182,7 +182,7 @@ public class OAuth2ClientImpl implements OAuth2Client
                 {
                     obj = body.getJSONObject(i);
                     list.add(new OAuth2GuildImpl(OAuth2ClientImpl.this, obj.getLong("id"),
-                        obj.getString("name"), obj.getString("icon"), obj.getBoolean("owner"),
+                        obj.getString("name"), obj.optString("icon"), obj.getBoolean("owner"),
                         obj.getInt("permissions")));
                 }
                 return list;

--- a/oauth2/src/main/java/com/jagrosh/jdautilities/oauth2/entities/impl/OAuth2ClientImpl.java
+++ b/oauth2/src/main/java/com/jagrosh/jdautilities/oauth2/entities/impl/OAuth2ClientImpl.java
@@ -182,7 +182,7 @@ public class OAuth2ClientImpl implements OAuth2Client
                 {
                     obj = body.getJSONObject(i);
                     list.add(new OAuth2GuildImpl(OAuth2ClientImpl.this, obj.getLong("id"),
-                        obj.getString("name"), obj.optString("icon"), obj.getBoolean("owner"),
+                        obj.getString("name"), obj.optString("icon", null), obj.getBoolean("owner"),
                         obj.getInt("permissions")));
                 }
                 return list;


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing
[pull-request]: https://github.com/JDA-Applications/JDA-Utilities/pulls

## Pull Request

#### Pull Request Checklist
Please follow the following steps before opening this PR.<br>
PRs that do not complete the checklist will be subject to denial for
missing information.

- [x] I have checked the [pull request page][pull-request] for upcoming
      or merged features/bug fixes.
- [x] I have read JDA's [contributing guidelines][contributing].

#### Pull Request Information
Check and fill in the blanks for all that apply:

- [x] My PR fixes a bug, error, or other issue with the library's codebase.
- [x] My PR is for the `OAuth2` module of the JDA-Utilities library.
- [ ] My PR creates a new module for the JDA-Utilities library: `______`.

#### Description

Switched to optString for getting the icon for a guild because when a guild doesn't have an icon it will throw a json error and fail.
