### PR TITLE
Experimental - Cancel-able Menus

### DIFF
--- a/commons/src/main/java/com/jagrosh/jdautilities/commons/waiter/EventWaiter.java
+++ b/commons/src/main/java/com/jagrosh/jdautilities/commons/waiter/EventWaiter.java
@@ -148,6 +148,9 @@ public class EventWaiter implements EventListener
      * @param  action
      *         The Consumer to perform an action when the condition Predicate returns {@code true}. Never null.
      *
+     * @return Future for canceling the waiting.
+     *         Using {@code Future#cancel(boolean)} with {@code mayInterruptIfRunning} set to {@code true} is not supported.
+     *
      * @throws IllegalArgumentException
      *         One of two reasons:
      *         <ul>
@@ -188,6 +191,9 @@ public class EventWaiter implements EventListener
      * @param  timeoutAction
      *         The Runnable to run if the time runs out before a correct Event is thrown, or
      *         {@code null} if there is no action on timeout.
+     *
+     * @return Future for canceling the waiting. This will call the timeoutAction if provided.
+     *         Using {@code Future#cancel(boolean)} with {@code mayInterruptIfRunning} set to {@code true} is not supported.
      *
      * @throws IllegalArgumentException
      *         One of two reasons:
@@ -308,11 +314,13 @@ public class EventWaiter implements EventListener
             @Override
             public boolean cancel(boolean mayInterruptIfRunning)
             {
+                if(mayInterruptIfRunning)
+                    throw new UnsupportedOperationException("EventWaiter#waitForEvent can not be cancelled with mayInterruptIfRunning set to true");
                 if(isDone() || isCancelled())
                     return isCancelled();
                 if(waitingEvents.get(classType).remove(WaitingEvent.this) && cancelAction != null)
                     cancelAction.run();
-                return super.cancel(mayInterruptIfRunning);
+                return super.cancel(false);
             }
         }
     }

--- a/commons/src/main/java/com/jagrosh/jdautilities/commons/waiter/EventWaiter.java
+++ b/commons/src/main/java/com/jagrosh/jdautilities/commons/waiter/EventWaiter.java
@@ -24,9 +24,7 @@ import net.dv8tion.jda.core.utils.Checks;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -157,9 +155,9 @@ public class EventWaiter implements EventListener
      *             <li>2) The internal threadpool is shut down, meaning that no more tasks can be submitted.</li>
      *         </ul>
      */
-    public <T extends Event> void waitForEvent(Class<T> classType, Predicate<T> condition, Consumer<T> action)
+    public <T extends Event> Future<Void> waitForEvent(Class<T> classType, Predicate<T> condition, Consumer<T> action)
     {
-        waitForEvent(classType, condition, action, -1, null, null);
+        return waitForEvent(classType, condition, action, -1, null, null);
     }
     
     /**
@@ -198,7 +196,7 @@ public class EventWaiter implements EventListener
      *             <li>2) The internal threadpool is shut down, meaning that no more tasks can be submitted.</li>
      *         </ul>
      */
-    public <T extends Event> void waitForEvent(Class<T> classType, Predicate<T> condition, Consumer<T> action,
+    public <T extends Event> Future<Void> waitForEvent(Class<T> classType, Predicate<T> condition, Consumer<T> action,
                                                long timeout, TimeUnit unit, Runnable timeoutAction)
     {
         Checks.check(!isShutdown(), "Attempted to register a WaitingEvent while the EventWaiter's threadpool was already shut down!");
@@ -206,18 +204,18 @@ public class EventWaiter implements EventListener
         Checks.notNull(condition, "The provided condition predicate");
         Checks.notNull(action, "The provided action consumer");
 
-        WaitingEvent we = new WaitingEvent<>(condition, action);
-        Set<WaitingEvent> set = waitingEvents.computeIfAbsent(classType, c -> new HashSet<>());
-        set.add(we);
+        WaitingEvent<T> we = new WaitingEvent<>(classType, condition, action, timeoutAction);
+        Future<Void> future = we.getFuture();
 
         if(timeout > 0 && unit != null)
         {
             threadpool.schedule(() ->
             {
-                if(set.remove(we) && timeoutAction != null)
-                    timeoutAction.run();
+                future.cancel(false);
             }, timeout, unit);
         }
+
+        return future;
     }
     
     @Override
@@ -268,16 +266,25 @@ public class EventWaiter implements EventListener
 
         threadpool.shutdown();
     }
-    
+
     private class WaitingEvent<T extends Event>
     {
+        final Class<T> classType;
         final Predicate<T> condition;
         final Consumer<T> action;
+        final Runnable cancelAction;
+        final CompletableFuture<Void> future = new WaitingFuture();
         
-        WaitingEvent(Predicate<T> condition, Consumer<T> action)
+        WaitingEvent(Class<T> classType, Predicate<T> condition, Consumer<T> action, Runnable cancelAction)
         {
+            this.classType = classType;
             this.condition = condition;
             this.action = action;
+            this.cancelAction = cancelAction;
+
+
+            Set<WaitingEvent> set = waitingEvents.computeIfAbsent(classType, c -> new HashSet<>());
+            set.add(this);
         }
         
         boolean attempt(T event)
@@ -285,9 +292,28 @@ public class EventWaiter implements EventListener
             if(condition.test(event))
             {
                 action.accept(event);
+                future.complete(null);
                 return true;
             }
             return false;
+        }
+
+        Future<Void> getFuture()
+        {
+            return future;
+        }
+
+        private class WaitingFuture extends CompletableFuture<Void>
+        {
+            @Override
+            public boolean cancel(boolean mayInterruptIfRunning)
+            {
+                if(isDone() || isCancelled())
+                    return isCancelled();
+                if(waitingEvents.get(classType).remove(WaitingEvent.this) && cancelAction != null)
+                    cancelAction.run();
+                return super.cancel(mayInterruptIfRunning);
+            }
         }
     }
 }

--- a/menu/src/main/java/com/jagrosh/jdautilities/menu/ButtonMenu.java
+++ b/menu/src/main/java/com/jagrosh/jdautilities/menu/ButtonMenu.java
@@ -50,7 +50,7 @@ public class ButtonMenu extends Menu
     private final List<String> choices;
     private final Consumer<ReactionEmote> action;
     private final Consumer<Message> finalAction;
-    
+
     ButtonMenu(EventWaiter waiter, Set<User> users, Set<Role> roles, long timeout, TimeUnit unit,
                Color color, String text, String description, List<String> choices, Consumer<ReactionEmote> action, Consumer<Message> finalAction)
     {
@@ -94,6 +94,7 @@ public class ButtonMenu extends Menu
     private void initialize(RestAction<Message> ra)
     {
         ra.queue(m -> {
+            setAttachedMessage(m);
             for(int i=0; i<choices.size(); i++)
             {
                 // Get the emote to display.
@@ -113,7 +114,7 @@ public class ButtonMenu extends Menu
                 {
                     // This is the last reaction added.
                     r.queue(v -> {
-                        waiter.waitForEvent(MessageReactionAddEvent.class, event -> {
+                        setCancelFuture(waiter.waitForEvent(MessageReactionAddEvent.class, event -> {
                             // If the message is not the same as the ButtonMenu
                             // currently being displayed.
                             if(!event.getMessageId().equals(m.getId()))
@@ -139,8 +140,8 @@ public class ButtonMenu extends Menu
 
                             // Preform the specified action with the ReactionEmote
                             action.accept(event.getReaction().getReactionEmote());
-                            finalAction.accept(m);
-                        }, timeout, unit, () -> finalAction.accept(m));
+                            callFinalAction(finalAction);
+                        }, timeout, unit, () -> callFinalAction(finalAction)));
                     });
                 }
             }

--- a/menu/src/main/java/com/jagrosh/jdautilities/menu/ButtonMenu.java
+++ b/menu/src/main/java/com/jagrosh/jdautilities/menu/ButtonMenu.java
@@ -49,18 +49,16 @@ public class ButtonMenu extends Menu
     private final String description;
     private final List<String> choices;
     private final Consumer<ReactionEmote> action;
-    private final Consumer<Message> finalAction;
 
     ButtonMenu(EventWaiter waiter, Set<User> users, Set<Role> roles, long timeout, TimeUnit unit,
                Color color, String text, String description, List<String> choices, Consumer<ReactionEmote> action, Consumer<Message> finalAction)
     {
-        super(waiter, users, roles, timeout, unit);
+        super(waiter, users, roles, timeout, unit, finalAction);
         this.color = color;
         this.text = text;
         this.description = description;
         this.choices = choices;
         this.action = action;
-        this.finalAction = finalAction;
     }
 
     /**
@@ -140,8 +138,8 @@ public class ButtonMenu extends Menu
 
                             // Preform the specified action with the ReactionEmote
                             action.accept(event.getReaction().getReactionEmote());
-                            callFinalAction(finalAction);
-                        }, timeout, unit, () -> callFinalAction(finalAction)));
+                            finalizeMenu();
+                        }, timeout, unit, this::finalizeMenu));
                     });
                 }
             }

--- a/menu/src/main/java/com/jagrosh/jdautilities/menu/Menu.java
+++ b/menu/src/main/java/com/jagrosh/jdautilities/menu/Menu.java
@@ -67,6 +67,11 @@ public abstract class Menu
     private Future<Void> cancelFuture;
     private Message attachedMessage;
 
+    protected Menu(EventWaiter waiter, Set<User> users, Set<Role> roles, long timeout, TimeUnit unit)
+    {
+        this(waiter, users, roles, timeout, unit, null);
+    }
+
     protected Menu(EventWaiter waiter, Set<User> users, Set<Role> roles, long timeout, TimeUnit unit, Consumer<Message> finalAction)
     {
         this.waiter = waiter;

--- a/menu/src/main/java/com/jagrosh/jdautilities/menu/Menu.java
+++ b/menu/src/main/java/com/jagrosh/jdautilities/menu/Menu.java
@@ -63,16 +63,18 @@ public abstract class Menu
     protected final long timeout;
     protected final TimeUnit unit;
 
+    private final Consumer<Message> finalAction;
     private Future<Void> cancelFuture;
     private Message attachedMessage;
-    
-    protected Menu(EventWaiter waiter, Set<User> users, Set<Role> roles, long timeout, TimeUnit unit)
+
+    protected Menu(EventWaiter waiter, Set<User> users, Set<Role> roles, long timeout, TimeUnit unit, Consumer<Message> finalAction)
     {
         this.waiter = waiter;
         this.users = users;
         this.roles = roles;
         this.timeout = timeout;
         this.unit = unit;
+        this.finalAction = finalAction;
     }
     
     /**
@@ -117,13 +119,23 @@ public abstract class Menu
         this.cancelFuture = cancelFuture;
     }
 
-    protected void callFinalAction(Consumer<Message> finalAction)
+    protected final Consumer<Message> getFinalAction()
+    {
+        return finalAction;
+    }
+
+    protected void finalizeMenu()
+    {
+        finalizeMenu(true);
+    }
+
+    protected void finalizeMenu(boolean callFinalAction)
     {
         Message tmp = this.attachedMessage;
         this.attachedMessage = null;
         //also clean up cancelFuture if not already
         this.cancelFuture = null;
-        if(finalAction != null)
+        if(callFinalAction && finalAction != null)
             finalAction.accept(tmp);
     }
 

--- a/menu/src/main/java/com/jagrosh/jdautilities/menu/Menu.java
+++ b/menu/src/main/java/com/jagrosh/jdautilities/menu/Menu.java
@@ -96,11 +96,22 @@ public abstract class Menu
      */
     public abstract void display(Message message);
 
+    /**
+     * Returns the message, this menu was attached to.
+     * This is set <b>asynchronously</b> after a call to a {@code display()} or equivalent method.
+     * <br>The attached message will be reset, when the menu times out or is cancelled.
+     *
+     * @return The message, this menu was attached to or {@code null} if not yet attached or already timed out/cancelled.
+     */
     public Message getAttachedMessage()
     {
         return attachedMessage;
     }
 
+    /**
+     * Cancels the menu. This stops the EventWaiter from waiting for events and behaves exactly the same way as if the menu timed out.
+     * That includes calling the final/cancel action if provided.
+     */
     public void cancel()
     {
         if(cancelFuture == null)
@@ -109,26 +120,61 @@ public abstract class Menu
         cancelFuture = null;
     }
 
+    /**
+     * Internally used to set the attached message.
+     * Should be used by the corresponding Menu implementation as soon as the message was created/edited.
+     *
+     * @param  attachedMessage
+     *         The message, where this menu was attached to
+     */
     protected final void setAttachedMessage(Message attachedMessage)
     {
         this.attachedMessage = attachedMessage;
     }
 
+    /**
+     * Internally used to set the cancelFuture used to cancel the menu.
+     * Should be used by the corresponding Menu implementation as soon as {@code EventWaiter#waitForEvent} was used.
+     *
+     * @param  cancelFuture
+     *         The cancel Future returned from {@code EventWaiter#waitForEvent}
+     */
     protected final void setCancelFuture(Future<Void> cancelFuture)
     {
         this.cancelFuture = cancelFuture;
     }
 
+    /**
+     * Returns the finalAction given via constructor.
+     *
+     * @return The finalAction given via constructor.
+     */
     protected final Consumer<Message> getFinalAction()
     {
         return finalAction;
     }
 
+    /**
+     * Calls the final action and cleans up the attached message and cancelFuture (sets them to {@code null}).
+     * <br>The actual Menu implementation should should call this method whenever the waiting loop is about to exit
+     * and the final action should be called (e.g. as timeout action for the EventWaiter).
+     *
+     * <p>This method is a shortcut for using {@link #finalizeMenu(boolean) finalizeMenu(true)}
+     *
+     * @see #finalizeMenu(boolean)
+     */
     protected void finalizeMenu()
     {
         finalizeMenu(true);
     }
 
+    /**
+     * Cleans up the attached message and cancelFuture (sets them to {@code null}) and optionally calls the final action.
+     * <br>The actual Menu implementation should should call this method whenever the waiting loop is about to exit
+     * and {@link #finalizeMenu() finalizeMenu()} is not applicable.
+     *
+     * @see #finalizeMenu()
+     */
     protected void finalizeMenu(boolean callFinalAction)
     {
         Message tmp = this.attachedMessage;

--- a/menu/src/main/java/com/jagrosh/jdautilities/menu/Paginator.java
+++ b/menu/src/main/java/com/jagrosh/jdautilities/menu/Paginator.java
@@ -399,7 +399,7 @@ public class Paginator extends Menu
     public static class Builder extends Menu.Builder<Builder, Paginator>
     {
         private BiFunction<Integer,Integer,Color> color = (page, pages) -> null;
-        private BiFunction<Integer,Integer,String> text = (page, pages) -> null;
+        private BiFunction<Integer,Integer,String> text = null;
         private Consumer<Message> finalAction = m -> m.delete().queue();
         private int columns = 1;
         private int itemsPerPage = 12;
@@ -483,7 +483,7 @@ public class Paginator extends Menu
          */
         public Builder setText(String text)
         {
-            this.text = (i0, i1) -> text;
+            this.text =  text == null ? null : (i0, i1) -> text;
             return this;
         }
 

--- a/menu/src/main/java/com/jagrosh/jdautilities/menu/SelectionDialog.java
+++ b/menu/src/main/java/com/jagrosh/jdautilities/menu/SelectionDialog.java
@@ -53,8 +53,7 @@ public class SelectionDialog extends Menu
     private final boolean loop;
     private final Function<Integer,String> text;
     private final BiConsumer<Message, Integer> success;
-    private final Consumer<Message> cancel;
-    
+
     public static final String UP = "\uD83D\uDD3C";
     public static final String DOWN = "\uD83D\uDD3D";
     public static final String SELECT = "\u2705";
@@ -65,7 +64,7 @@ public class SelectionDialog extends Menu
                     Function<Integer,Color> color, boolean loop, BiConsumer<Message, Integer> success,
                     Consumer<Message> cancel, Function<Integer,String> text)
     {
-        super(waiter, users, roles, timeout, unit);
+        super(waiter, users, roles, timeout, unit, cancel);
         this.choices = choices;
         this.leftEnd = leftEnd;
         this.rightEnd = rightEnd;
@@ -74,7 +73,6 @@ public class SelectionDialog extends Menu
         this.color = color;
         this.loop = loop;
         this.success = success;
-        this.cancel = cancel;
         this.text = text;
     }
 
@@ -195,7 +193,7 @@ public class SelectionDialog extends Menu
                     success.accept(getAttachedMessage(), selection);
                     break;
                 case CANCEL:
-                    callFinalAction(cancel);
+                    finalizeMenu();
                     return;
 
             }
@@ -204,7 +202,7 @@ public class SelectionDialog extends Menu
             } catch (PermissionException ignored) {}
             int n = newSelection;
             getAttachedMessage().editMessage(render(n)).queue(m -> selectionDialog(n));
-        }, timeout, unit, () -> callFinalAction(cancel)));
+        }, timeout, unit, this::finalizeMenu));
     }
     
     private Message render(int selection)

--- a/menu/src/main/java/com/jagrosh/jdautilities/menu/Slideshow.java
+++ b/menu/src/main/java/com/jagrosh/jdautilities/menu/Slideshow.java
@@ -56,7 +56,6 @@ public class Slideshow extends Menu
     private final BiFunction<Integer,Integer,String> description;
     private final boolean showPageNumbers;
     private final List<String> urls;
-    private final Consumer<Message> finalAction;
     private final boolean waitOnSinglePage;
     private final int bulkSkipNumber;
     private final boolean wrapPageEnds;
@@ -77,13 +76,12 @@ public class Slideshow extends Menu
               int bulkSkipNumber, boolean wrapPageEnds, String leftText, String rightText,
               boolean allowTextInput)
     {
-        super(waiter, users, roles, timeout, unit);
+        super(waiter, users, roles, timeout, unit, finalAction);
         this.color = color;
         this.text = text;
         this.description = description;
         this.showPageNumbers = showPageNumbers;
         this.urls = items;
-        this.finalAction = finalAction;
         this.waitOnSinglePage = waitOnSinglePage;
         this.bulkSkipNumber = bulkSkipNumber;
         this.wrapPageEnds = wrapPageEnds;
@@ -179,7 +177,7 @@ public class Slideshow extends Menu
             }
             else
             {
-                callFinalAction(finalAction);
+                finalizeMenu();
             }
         });
     }
@@ -250,7 +248,7 @@ public class Slideshow extends Menu
                 getAttachedMessage().editMessage(renderPage(targetPage)).queue(m -> pagination(targetPage));
                 mre.getMessage().delete().queue(v -> {}, t -> {}); // delete the calling message so it doesn't get spammy
             }
-        }, timeout, unit, () -> callFinalAction(finalAction)));
+        }, timeout, unit, this::finalizeMenu));
     }
 
     private void paginationWithoutTextInput(int pageNum)
@@ -258,7 +256,7 @@ public class Slideshow extends Menu
         setCancelFuture(waiter.waitForEvent(MessageReactionAddEvent.class,
             event -> checkReaction(event),
             event -> handleMessageReactionAddAction(event, pageNum),
-            timeout, unit, () -> callFinalAction(finalAction)));
+            timeout, unit, this::finalizeMenu));
     }
 
     // Private method that checks MessageReactionAddEvents
@@ -325,7 +323,7 @@ public class Slideshow extends Menu
                 }
                 break;
             case STOP:
-                callFinalAction(finalAction);
+                finalizeMenu();
                 return;
         }
 


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing
[pull-request]: https://github.com/JDA-Applications/JDA-Utilities/pulls

## Pull Request

#### Pull Request Checklist
Please follow the following steps before opening this PR.<br>
PRs that do not complete the checklist will be subject to denial for
missing information.

- [x] I have checked the [pull request page][pull-request] for upcoming
      or merged features/bug fixes.
- [x] I have read JDA's [contributing guidelines][contributing].

#### Pull Request Information
Check and fill in the blanks for all that apply:

- [ ] My PR fixes a bug, error, or other issue with the library's codebase.
- [x] My PR is for the `menu` and `commons` modules of the JDA-Utilities library.
- [ ] My PR creates a new module for the JDA-Utilities library: `______`.

#### Description

This module adds the possibility to cancel `EventWaiter` tasks via the new return value of `EventWaiter#waitForEvent` (`Future<Void>`)

This new feature is used to add `Menu#cancel()` to cancel menus that are already running.

#### Todo:

- [ ] Discuss if this is the proper way of doing this or if some mechanics should be changed
- [x] Javadocs
- [x] Decide how to handle `cancelFuture.cancel(true)` vs `false`
- [ ] Should there be a cancel method that doesn't execute the cancel/final action? What about the EventWaiter cancellation?
- [ ] Eventually throw errors on `display()` if already being displayed somewhere, as this would currently prevent proper functionality of `Menu#cancel()`
- [ ] Wait for PR #58 to be merged and patch it as well in this PR
- [ ] Extensive testing
- [ ] Final review