### PR TITLE
Selection menu enhancement - Added abstract SelectionMenu and ScrollSelection

### DIFF
--- a/menu/src/main/java/com/jagrosh/jdautilities/menu/ScrollSelection.java
+++ b/menu/src/main/java/com/jagrosh/jdautilities/menu/ScrollSelection.java
@@ -31,10 +31,10 @@ public class ScrollSelection extends SelectionMenu
     private final String format;
 
     private ScrollSelection(EventWaiter waiter, Set<User> users, Set<Role> roles, long timeout, TimeUnit unit,
-                            List<String> choices, Function<Integer, Color> color, boolean loop, BiConsumer<Message, Integer> success,
+                            List<String> choices, Function<Integer, Color> color, boolean loop, boolean singleSelectionMode, BiConsumer<Message, Integer> success,
                             Consumer<Message> cancel, Function<Integer, String> text, String format)
     {
-        super(waiter, users, roles, timeout, unit, choices, loop, cancel, color, text, success, Arrays.asList(UP, SELECT, CANCEL, DOWN));
+        super(waiter, users, roles, timeout, unit, choices, loop, singleSelectionMode, cancel, color, text, success, Arrays.asList(UP, SELECT, CANCEL, DOWN));
         this.format = format;
     }
 
@@ -84,10 +84,11 @@ public class ScrollSelection extends SelectionMenu
             Checks.check(!choices.isEmpty(), "Must have at least one choice");
             Checks.check(selection != null, "Must provide a selection consumer");
             Checks.check(format != null, "Must set a format String");
-            Checks.check(format.split("%s").length == 2, "Format String must contain one String formatter (%s), no more, no less");
+            // TODO check if String only contains 1 formatter
+            // Checks.check(true, "Format String must contain one String formatter (%s), no more, no less");
 
             return new ScrollSelection(waiter, users, roles, timeout, unit, choices,
-                color, loop, selection, cancel, text, format);
+                color, loop, singleSelectionMode, selection, cancel, text, format);
         }
 
         /**

--- a/menu/src/main/java/com/jagrosh/jdautilities/menu/ScrollSelection.java
+++ b/menu/src/main/java/com/jagrosh/jdautilities/menu/ScrollSelection.java
@@ -9,7 +9,6 @@ import net.dv8tion.jda.core.entities.User;
 import net.dv8tion.jda.core.utils.Checks;
 
 import java.awt.Color;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
@@ -26,7 +25,7 @@ import java.util.function.Function;
  *
  * @author Johnny_JayJay (https://github.com/johnnyjayjay)
  */
-public class ScrollSelection extends SelectionDialog
+public class ScrollSelection extends SelectionMenu
 {
 
     private final String format;
@@ -35,38 +34,31 @@ public class ScrollSelection extends SelectionDialog
                             List<String> choices, Function<Integer, Color> color, boolean loop, BiConsumer<Message, Integer> success,
                             Consumer<Message> cancel, Function<Integer, String> text, String format)
     {
-        super(waiter, users, roles, timeout, unit, choices, null, null, null, null, color, loop, success, cancel, text);
+        super(waiter, users, roles, timeout, unit, choices, loop, cancel, color, text, success, Arrays.asList(UP, SELECT, CANCEL, DOWN));
         this.format = format;
     }
 
     @Override
     protected Message render(int selection)
     {
-        String content = text.apply(selection);
+        String content = textFunction.apply(selection);
         return new MessageBuilder()
             .setContent(content != null ? content : "")
             .setEmbed(new EmbedBuilder()
-                .setColor(color.apply(selection))
+                .setColor(colorFunction.apply(selection))
                 .setDescription(String.format(format, choices.get(selection - 1)))
                 .build())
             .build();
     }
 
     /**
-     * The {@link com.jagrosh.jdautilities.menu.Menu.Builder Menu.Builder} for
-     * a {@link com.jagrosh.jdautilities.menu.ScrollSelection ScrollSelection}.
+     * The Builder for a {@link com.jagrosh.jdautilities.menu.ScrollSelection ScrollSelection} Menu.
      *
      * @author Johnny_JayJay (https://github.com/johnnyjayjay)
      */
-    public static class Builder extends Menu.Builder<Builder, ScrollSelection>
+    public static class Builder extends SelectionMenu.Builder<Builder, ScrollSelection>
     {
 
-        private final List<String> choices = new ArrayList<>();
-        private Function<Integer,Color> color = i -> null;
-        private boolean loop = true;
-        private Function<Integer,String> text = i -> null;
-        private BiConsumer<Message, Integer> selection;
-        private Consumer<Message> cancel = (m) -> {};
         private String format = null;
 
         /**
@@ -96,159 +88,6 @@ public class ScrollSelection extends SelectionDialog
 
             return new ScrollSelection(waiter, users, roles, timeout, unit, choices,
                 color, loop, selection, cancel, text, format);
-        }
-
-        /**
-         * Sets the {@link java.awt.Color Color} of the {@link net.dv8tion.jda.core.entities.MessageEmbed MessageEmbed}.
-         *
-         * @param  color
-         *         The Color of the MessageEmbed
-         *
-         * @return This builder
-         */
-        public Builder setColor(Color color)
-        {
-            this.color = i -> color;
-            return this;
-        }
-
-        /**
-         * Sets the {@link java.awt.Color Color} of the {@link net.dv8tion.jda.core.entities.MessageEmbed MessageEmbed},
-         * relative to the current selection number as determined by the provided
-         * {@link java.util.function.Function Function}.
-         * <br>As the selection changes, the Function will re-process the current selection number,
-         * allowing for the color of the embed to change depending on the selection number.
-         *
-         * @param  color
-         *         A Function that uses current selection number to get a Color for the MessageEmbed
-         *
-         * @return This builder
-         */
-        public Builder setColor(Function<Integer,Color> color)
-        {
-            this.color = color;
-            return this;
-        }
-
-        /**
-         * Sets the text of the {@link net.dv8tion.jda.core.entities.Message Message} to be displayed
-         * when the {@link com.jagrosh.jdautilities.menu.SelectionDialog SelectionDialog} is built.
-         *
-         * <p>This is displayed directly above the embed.
-         *
-         * @param  text
-         *         The Message content to be displayed above the embed when the SelectionDialog is built
-         *
-         * @return This builder
-         */
-        public Builder setText(String text)
-        {
-            this.text = i -> text;
-            return this;
-        }
-
-        /**
-         * Sets the text of the {@link net.dv8tion.jda.core.entities.Message Message} to be displayed
-         * relative to the current selection number as determined by the provided
-         * {@link java.util.function.Function Function}.
-         * <br>As the selection changes, the Function will re-process the current selection number,
-         * allowing for the displayed text of the Message to change depending on the selection number.
-         *
-         * @param  text
-         *         A Function that uses current selection number to get a text for the Message
-         *
-         * @return This builder
-         */
-        public Builder setText(Function<Integer,String> text)
-        {
-            this.text = text;
-            return this;
-        }
-
-        /**
-         * Sets if scrolling up when at the top selection jumps to the last selection, and vice versa.
-         *
-         * @param  loop
-         *         {@code true} if pressing up while at the top selection should loop
-         *         to the bottom, {@code false} if it should not
-         *
-         * @return This builder
-         */
-        public Builder useLooping(boolean loop)
-        {
-            this.loop = loop;
-            return this;
-        }
-
-        /**
-         * Sets a {@link java.util.function.BiConsumer BiConsumer} action to perform once a selection is made.
-         * <br>The {@link net.dv8tion.jda.core.entities.Message Message} provided is the one used to display
-         * the menu and the {@link java.lang.Integer Integer} is that of the selection made by the user,
-         * and selections are in order of addition, 1 being the first String choice.
-         *
-         * @param  selection
-         *         A Consumer for the selection. This is one-based indexing.
-         *
-         * @return This builder
-         */
-        public Builder setSelectionConsumer(BiConsumer<Message, Integer> selection)
-        {
-            this.selection = selection;
-            return this;
-        }
-
-        /**
-         * Sets a {@link java.util.function.Consumer Consumer} action to take if the menu is cancelled, either
-         * via the cancel button being used, or if the SelectionDialog times out.
-         *
-         * @param  cancel
-         *         The action to take when the SelectionDialog is cancelled
-         *
-         * @return This builder
-         */
-        public Builder setCanceled(Consumer<Message> cancel)
-        {
-            this.cancel = cancel;
-            return this;
-        }
-
-        /**
-         * Clears the choices to be shown.
-         *
-         * @return This builder
-         */
-        public Builder clearChoices()
-        {
-            this.choices.clear();
-            return this;
-        }
-
-        /**
-         * Sets the String choices to be shown as selections.
-         *
-         * @param  choices
-         *         The String choices to show
-         * @return the builder
-         */
-        public Builder setChoices(String... choices)
-        {
-            this.choices.clear();
-            this.choices.addAll(Arrays.asList(choices));
-            return this;
-        }
-
-        /**
-         * Adds String choices to be shown as selections.
-         *
-         * @param  choices
-         *         The String choices to add
-         *
-         * @return This builder
-         */
-        public Builder addChoices(String... choices)
-        {
-            this.choices.addAll(Arrays.asList(choices));
-            return this;
         }
 
         /**

--- a/menu/src/main/java/com/jagrosh/jdautilities/menu/ScrollSelection.java
+++ b/menu/src/main/java/com/jagrosh/jdautilities/menu/ScrollSelection.java
@@ -84,8 +84,7 @@ public class ScrollSelection extends SelectionMenu
             Checks.check(!choices.isEmpty(), "Must have at least one choice");
             Checks.check(selection != null, "Must provide a selection consumer");
             Checks.check(format != null, "Must set a format String");
-            // TODO check if String only contains 1 formatter
-            // Checks.check(true, "Format String must contain one String formatter (%s), no more, no less");
+            Checks.check(format.indexOf("%s") == format.lastIndexOf("%s"), "Format String must contain one String formatter (%s), no more, no less");
 
             return new ScrollSelection(waiter, users, roles, timeout, unit, choices,
                 color, loop, singleSelectionMode, selection, cancel, text, format);

--- a/menu/src/main/java/com/jagrosh/jdautilities/menu/ScrollSelection.java
+++ b/menu/src/main/java/com/jagrosh/jdautilities/menu/ScrollSelection.java
@@ -34,7 +34,8 @@ public class ScrollSelection extends SelectionMenu
                             List<String> choices, Function<Integer, Color> color, boolean loop, boolean singleSelectionMode, BiConsumer<Message, Integer> success,
                             Consumer<Message> cancel, Function<Integer, String> text, String format)
     {
-        super(waiter, users, roles, timeout, unit, choices, loop, singleSelectionMode, cancel, color, text, success, Arrays.asList(UP, SELECT, CANCEL, DOWN));
+        super(waiter, users, roles, timeout, unit, choices, loop, singleSelectionMode, cancel, color, text, success,
+            Arrays.asList(SelectionMenu.SELECT, SelectionMenu.UP, SelectionMenu.DOWN, SelectionMenu.CANCEL));
         this.format = format;
     }
 

--- a/menu/src/main/java/com/jagrosh/jdautilities/menu/ScrollSelection.java
+++ b/menu/src/main/java/com/jagrosh/jdautilities/menu/ScrollSelection.java
@@ -1,0 +1,272 @@
+package com.jagrosh.jdautilities.menu;
+
+import com.jagrosh.jdautilities.commons.waiter.EventWaiter;
+import net.dv8tion.jda.core.EmbedBuilder;
+import net.dv8tion.jda.core.MessageBuilder;
+import net.dv8tion.jda.core.entities.Message;
+import net.dv8tion.jda.core.entities.Role;
+import net.dv8tion.jda.core.entities.User;
+import net.dv8tion.jda.core.utils.Checks;
+
+import java.awt.Color;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+/**
+ * A {@link com.jagrosh.jdautilities.menu.Menu Menu} implementation that creates
+ * a scrollable display of text choices that users can scroll through.
+ * <br>This is very similar to the {@link com.jagrosh.jdautilities.menu.SelectionDialog SelectionDialog},
+ * though it only displays the current selection and provides the possibility to design the selection display freely.
+ *
+ * @author Johnny_JayJay (https://github.com/johnnyjayjay)
+ */
+public class ScrollSelection extends SelectionDialog
+{
+
+    private final String format;
+
+    private ScrollSelection(EventWaiter waiter, Set<User> users, Set<Role> roles, long timeout, TimeUnit unit,
+                            List<String> choices, Function<Integer, Color> color, boolean loop, BiConsumer<Message, Integer> success,
+                            Consumer<Message> cancel, Function<Integer, String> text, String format)
+    {
+        super(waiter, users, roles, timeout, unit, choices, null, null, null, null, color, loop, success, cancel, text);
+        this.format = format;
+    }
+
+    @Override
+    protected Message render(int selection)
+    {
+        String content = text.apply(selection);
+        return new MessageBuilder()
+            .setContent(content != null ? content : "")
+            .setEmbed(new EmbedBuilder()
+                .setColor(color.apply(selection))
+                .setDescription(String.format(format, choices.get(selection - 1)))
+                .build())
+            .build();
+    }
+
+    /**
+     * The {@link com.jagrosh.jdautilities.menu.Menu.Builder Menu.Builder} for
+     * a {@link com.jagrosh.jdautilities.menu.ScrollSelection ScrollSelection}.
+     *
+     * @author Johnny_JayJay (https://github.com/johnnyjayjay)
+     */
+    public static class Builder extends Menu.Builder<Builder, ScrollSelection>
+    {
+
+        private final List<String> choices = new ArrayList<>();
+        private Function<Integer,Color> color = i -> null;
+        private boolean loop = true;
+        private Function<Integer,String> text = i -> null;
+        private BiConsumer<Message, Integer> selection;
+        private Consumer<Message> cancel = (m) -> {};
+        private String format = null;
+
+        /**
+         * Builds the {@link com.jagrosh.jdautilities.menu.ScrollSelection ScrollSelection}
+         * with this Builder.
+         *
+         * @return The ScrollSelection built from this Builder.
+         *
+         * @throws java.lang.IllegalArgumentException
+         *         If one of the following is violated:
+         *         <ul>
+         *             <li>No {@link com.jagrosh.jdautilities.commons.waiter.EventWaiter EventWaiter} was set.</li>
+         *             <li>No choices were set.</li>
+         *             <li>No action {@link java.util.function.BiConsumer BiConsumer} was set.</li>
+         *             <li>No format String was set.</li>
+         *             <li>The format String does not contain one String formatter ({@code %s}) exactly.</li>
+         *         </ul>
+         */
+        @Override
+        public ScrollSelection build()
+        {
+            Checks.check(waiter != null, "Must set an EventWaiter");
+            Checks.check(!choices.isEmpty(), "Must have at least one choice");
+            Checks.check(selection != null, "Must provide a selection consumer");
+            Checks.check(format != null, "Must set a format String");
+            Checks.check(format.split("%s").length == 2, "Format String must contain one String formatter (%s), no more, no less");
+
+            return new ScrollSelection(waiter, users, roles, timeout, unit, choices,
+                color, loop, selection, cancel, text, format);
+        }
+
+        /**
+         * Sets the {@link java.awt.Color Color} of the {@link net.dv8tion.jda.core.entities.MessageEmbed MessageEmbed}.
+         *
+         * @param  color
+         *         The Color of the MessageEmbed
+         *
+         * @return This builder
+         */
+        public Builder setColor(Color color)
+        {
+            this.color = i -> color;
+            return this;
+        }
+
+        /**
+         * Sets the {@link java.awt.Color Color} of the {@link net.dv8tion.jda.core.entities.MessageEmbed MessageEmbed},
+         * relative to the current selection number as determined by the provided
+         * {@link java.util.function.Function Function}.
+         * <br>As the selection changes, the Function will re-process the current selection number,
+         * allowing for the color of the embed to change depending on the selection number.
+         *
+         * @param  color
+         *         A Function that uses current selection number to get a Color for the MessageEmbed
+         *
+         * @return This builder
+         */
+        public Builder setColor(Function<Integer,Color> color)
+        {
+            this.color = color;
+            return this;
+        }
+
+        /**
+         * Sets the text of the {@link net.dv8tion.jda.core.entities.Message Message} to be displayed
+         * when the {@link com.jagrosh.jdautilities.menu.SelectionDialog SelectionDialog} is built.
+         *
+         * <p>This is displayed directly above the embed.
+         *
+         * @param  text
+         *         The Message content to be displayed above the embed when the SelectionDialog is built
+         *
+         * @return This builder
+         */
+        public Builder setText(String text)
+        {
+            this.text = i -> text;
+            return this;
+        }
+
+        /**
+         * Sets the text of the {@link net.dv8tion.jda.core.entities.Message Message} to be displayed
+         * relative to the current selection number as determined by the provided
+         * {@link java.util.function.Function Function}.
+         * <br>As the selection changes, the Function will re-process the current selection number,
+         * allowing for the displayed text of the Message to change depending on the selection number.
+         *
+         * @param  text
+         *         A Function that uses current selection number to get a text for the Message
+         *
+         * @return This builder
+         */
+        public Builder setText(Function<Integer,String> text)
+        {
+            this.text = text;
+            return this;
+        }
+
+        /**
+         * Sets if scrolling up when at the top selection jumps to the last selection, and vice versa.
+         *
+         * @param  loop
+         *         {@code true} if pressing up while at the top selection should loop
+         *         to the bottom, {@code false} if it should not
+         *
+         * @return This builder
+         */
+        public Builder useLooping(boolean loop)
+        {
+            this.loop = loop;
+            return this;
+        }
+
+        /**
+         * Sets a {@link java.util.function.BiConsumer BiConsumer} action to perform once a selection is made.
+         * <br>The {@link net.dv8tion.jda.core.entities.Message Message} provided is the one used to display
+         * the menu and the {@link java.lang.Integer Integer} is that of the selection made by the user,
+         * and selections are in order of addition, 1 being the first String choice.
+         *
+         * @param  selection
+         *         A Consumer for the selection. This is one-based indexing.
+         *
+         * @return This builder
+         */
+        public Builder setSelectionConsumer(BiConsumer<Message, Integer> selection)
+        {
+            this.selection = selection;
+            return this;
+        }
+
+        /**
+         * Sets a {@link java.util.function.Consumer Consumer} action to take if the menu is cancelled, either
+         * via the cancel button being used, or if the SelectionDialog times out.
+         *
+         * @param  cancel
+         *         The action to take when the SelectionDialog is cancelled
+         *
+         * @return This builder
+         */
+        public Builder setCanceled(Consumer<Message> cancel)
+        {
+            this.cancel = cancel;
+            return this;
+        }
+
+        /**
+         * Clears the choices to be shown.
+         *
+         * @return This builder
+         */
+        public Builder clearChoices()
+        {
+            this.choices.clear();
+            return this;
+        }
+
+        /**
+         * Sets the String choices to be shown as selections.
+         *
+         * @param  choices
+         *         The String choices to show
+         * @return the builder
+         */
+        public Builder setChoices(String... choices)
+        {
+            this.choices.clear();
+            this.choices.addAll(Arrays.asList(choices));
+            return this;
+        }
+
+        /**
+         * Adds String choices to be shown as selections.
+         *
+         * @param  choices
+         *         The String choices to add
+         *
+         * @return This builder
+         */
+        public Builder addChoices(String... choices)
+        {
+            this.choices.addAll(Arrays.asList(choices));
+            return this;
+        }
+
+        /**
+         * Sets the format in which this selection is presented.
+         * <br>Example: {@code "```\n%s```"} as a parameter would result in a format
+         * that always shows the current selection in a code block
+         * (the {@code %s} is replaced by the current selection later)
+         *
+         * @param  format
+         *         The format String. Must contain one String formatter ({@code "%s"}), no more, no less.
+         *
+         * @return This builder
+         */
+        public Builder setFormat(String format)
+        {
+            this.format = format;
+            return this;
+        }
+
+    }
+}

--- a/menu/src/main/java/com/jagrosh/jdautilities/menu/SelectionDialog.java
+++ b/menu/src/main/java/com/jagrosh/jdautilities/menu/SelectionDialog.java
@@ -15,16 +15,6 @@
  */
 package com.jagrosh.jdautilities.menu;
 
-import java.awt.Color;
-import java.util.Arrays;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
-import java.util.function.BiConsumer;
-import java.util.function.Consumer;
-import java.util.function.Function;
-
 import com.jagrosh.jdautilities.commons.waiter.EventWaiter;
 import net.dv8tion.jda.core.EmbedBuilder;
 import net.dv8tion.jda.core.MessageBuilder;
@@ -32,6 +22,15 @@ import net.dv8tion.jda.core.entities.Message;
 import net.dv8tion.jda.core.entities.Role;
 import net.dv8tion.jda.core.entities.User;
 import net.dv8tion.jda.core.utils.Checks;
+
+import java.awt.Color;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
 /**
  * A {@link com.jagrosh.jdautilities.menu.Menu Menu} implementation that creates
@@ -48,16 +47,17 @@ public class SelectionDialog extends SelectionMenu
     
     private SelectionDialog(EventWaiter waiter, Set<User> users, Set<Role> roles, long timeout, TimeUnit unit,
                     List<String> choices, String leftEnd, String rightEnd, String defaultLeft, String defaultRight,
-                    Function<Integer,Color> color, boolean loop, BiConsumer<Message, Integer> success,
+                    Function<Integer, Color> color, boolean loop, boolean singleSelectionMode, BiConsumer<Message, Integer> success,
                     Consumer<Message> cancel, Function<Integer,String> text)
     {
-        super(waiter, users, roles, timeout, unit, choices, loop, cancel, color, text, success, Arrays.asList(SELECT, UP, DOWN, CANCEL));
+        super(waiter, users, roles, timeout, unit, choices, loop, singleSelectionMode, cancel, color, text, success, Arrays.asList(SELECT, UP, DOWN, CANCEL));
         this.leftEnd = leftEnd;
         this.rightEnd = rightEnd;
         this.defaultLeft = defaultLeft;
         this.defaultRight = defaultRight;
     }
-    
+
+    @Override
     protected Message render(int selection)
     {
         StringBuilder sbuilder = new StringBuilder();
@@ -112,7 +112,7 @@ public class SelectionDialog extends SelectionMenu
             Checks.check(selection != null, "Must provide a selection consumer");
 
             return new SelectionDialog(waiter,users,roles,timeout,unit,choices,leftEnd,rightEnd,
-                    defaultLeft,defaultRight,color,loop, selection, cancel,text);
+                    defaultLeft,defaultRight,color,loop, singleSelectionMode, selection, cancel,text);
         }
 
         /**

--- a/menu/src/main/java/com/jagrosh/jdautilities/menu/SelectionDialog.java
+++ b/menu/src/main/java/com/jagrosh/jdautilities/menu/SelectionDialog.java
@@ -29,12 +29,8 @@ import com.jagrosh.jdautilities.commons.waiter.EventWaiter;
 import net.dv8tion.jda.core.EmbedBuilder;
 import net.dv8tion.jda.core.MessageBuilder;
 import net.dv8tion.jda.core.entities.Message;
-import net.dv8tion.jda.core.entities.MessageChannel;
 import net.dv8tion.jda.core.entities.Role;
 import net.dv8tion.jda.core.entities.User;
-import net.dv8tion.jda.core.events.message.react.MessageReactionAddEvent;
-import net.dv8tion.jda.core.exceptions.PermissionException;
-import net.dv8tion.jda.core.requests.RestAction;
 import net.dv8tion.jda.core.utils.Checks;
 
 /**
@@ -44,166 +40,22 @@ import net.dv8tion.jda.core.utils.Checks;
  *
  * @author John Grosh
  */
-public class SelectionDialog extends Menu
+public class SelectionDialog extends SelectionMenu
 {
-    protected final List<String> choices;
     private final String leftEnd, rightEnd;
     private final String defaultLeft, defaultRight;
-    protected final Function<Integer,Color> color;
-    private final boolean loop;
-    protected final Function<Integer,String> text;
-    private final BiConsumer<Message, Integer> success;
-    private final Consumer<Message> cancel;
+
     
-    public static final String UP = "\uD83D\uDD3C";
-    public static final String DOWN = "\uD83D\uDD3D";
-    public static final String SELECT = "\u2705";
-    public static final String CANCEL = "\u274E";
-    
-    SelectionDialog(EventWaiter waiter, Set<User> users, Set<Role> roles, long timeout, TimeUnit unit,
+    private SelectionDialog(EventWaiter waiter, Set<User> users, Set<Role> roles, long timeout, TimeUnit unit,
                     List<String> choices, String leftEnd, String rightEnd, String defaultLeft, String defaultRight,
                     Function<Integer,Color> color, boolean loop, BiConsumer<Message, Integer> success,
                     Consumer<Message> cancel, Function<Integer,String> text)
     {
-        super(waiter, users, roles, timeout, unit);
-        this.choices = choices;
+        super(waiter, users, roles, timeout, unit, choices, loop, cancel, color, text, success, Arrays.asList(SELECT, UP, DOWN, CANCEL));
         this.leftEnd = leftEnd;
         this.rightEnd = rightEnd;
         this.defaultLeft = defaultLeft;
         this.defaultRight = defaultRight;
-        this.color = color;
-        this.loop = loop;
-        this.success = success;
-        this.cancel = cancel;
-        this.text = text;
-    }
-
-    /**
-     * Shows the SelectionDialog as a new {@link net.dv8tion.jda.core.entities.Message Message} 
-     * in the provided {@link net.dv8tion.jda.core.entities.MessageChannel MessageChannel}, starting with
-     * the first selection.
-     * 
-     * @param  channel
-     *         The MessageChannel to send the new Message to
-     */
-    @Override
-    public void display(MessageChannel channel)
-    {
-        showDialog(channel, 1);
-    }
-
-    /**
-     * Displays this SelectionDialog by editing the provided 
-     * {@link net.dv8tion.jda.core.entities.Message Message}, starting with the first selection.
-     * 
-     * @param  message
-     *         The Message to display the Menu in
-     */
-    @Override
-    public void display(Message message)
-    {
-        showDialog(message, 1);
-    }
-    
-    /**
-     * Shows the SelectionDialog as a new {@link net.dv8tion.jda.core.entities.Message Message} 
-     * in the provided {@link net.dv8tion.jda.core.entities.MessageChannel MessageChannel}, starting with
-     * the number selection provided.
-     * 
-     * @param  channel
-     *         The MessageChannel to send the new Message to
-     * @param  selection
-     *         The number selection to start on
-     */
-    public void showDialog(MessageChannel channel, int selection)
-    {
-        if(selection<1)
-            selection = 1;
-        else if(selection>choices.size())
-            selection = choices.size();
-        Message msg = render(selection);
-        initialize(channel.sendMessage(msg), selection);
-    }
-    
-    /**
-     * Displays this SelectionDialog by editing the provided 
-     * {@link net.dv8tion.jda.core.entities.Message Message}, starting with the number selection
-     * provided.
-     * 
-     * @param  message
-     *         The Message to display the Menu in
-     * @param  selection
-     *         The number selection to start on
-     */
-    public void showDialog(Message message, int selection)
-    {
-        if(selection<1)
-            selection = 1;
-        else if(selection>choices.size())
-            selection = choices.size();
-        Message msg = render(selection);
-        initialize(message.editMessage(msg), selection);
-    }
-    
-    private void initialize(RestAction<Message> action, int selection)
-    {
-        action.queue(m -> {
-            if(choices.size()>1)
-            {
-                m.addReaction(UP).queue();
-                m.addReaction(SELECT).queue();
-                m.addReaction(CANCEL).queue();
-                m.addReaction(DOWN).queue(v -> selectionDialog(m, selection), v -> selectionDialog(m, selection));
-            }
-            else
-            {
-                m.addReaction(SELECT).queue();
-                m.addReaction(CANCEL).queue(v -> selectionDialog(m, selection), v -> selectionDialog(m, selection));
-            }
-        });
-    }
-    
-    private void selectionDialog(Message message, int selection)
-    {
-        waiter.waitForEvent(MessageReactionAddEvent.class, event -> {
-            if(!event.getMessageId().equals(message.getId()))
-                return false;
-            if(!(UP.equals(event.getReaction().getReactionEmote().getName())
-                    || DOWN.equals(event.getReaction().getReactionEmote().getName())
-                    || CANCEL.equals(event.getReaction().getReactionEmote().getName())
-                    || SELECT.equals(event.getReaction().getReactionEmote().getName())))
-                return false;
-            return isValidUser(event.getUser(), event.getGuild());
-        }, event -> {
-            int newSelection = selection;
-            switch(event.getReaction().getReactionEmote().getName())
-            {
-                case UP:
-                    if(newSelection>1)
-                        newSelection--;
-                    else if(loop)
-                        newSelection = choices.size();
-                    break;
-                case DOWN:
-                    if(newSelection<choices.size())
-                        newSelection++;
-                    else if(loop)
-                        newSelection = 1;
-                    break;
-                case SELECT:
-                    success.accept(message, selection);
-                    break;
-                case CANCEL:
-                    cancel.accept(message);
-                    return;
-
-            }
-            try {
-                event.getReaction().removeReaction(event.getUser()).queue();
-            } catch (PermissionException ignored) {}
-            int n = newSelection;
-            message.editMessage(render(n)).queue(m -> selectionDialog(m, n));
-        }, timeout, unit, () -> cancel.accept(message));
     }
     
     protected Message render(int selection)
@@ -215,11 +67,11 @@ public class SelectionDialog extends Menu
             else
                 sbuilder.append("\n").append(defaultLeft).append(choices.get(i)).append(defaultRight);
         MessageBuilder mbuilder = new MessageBuilder();
-        String content = text.apply(selection);
+        String content = textFunction.apply(selection);
         if(content!=null)
             mbuilder.append(content);
         return mbuilder.setEmbed(new EmbedBuilder()
-                .setColor(color.apply(selection))
+                .setColor(colorFunction.apply(selection))
                 .setDescription(sbuilder.toString())
                 .build()).build();
     }
@@ -230,18 +82,13 @@ public class SelectionDialog extends Menu
      *
      * @author John Grosh
      */
-    public static class Builder extends Menu.Builder<Builder, SelectionDialog>
+    public static class Builder extends SelectionMenu.Builder<Builder, SelectionDialog>
     {
-        private final List<String> choices = new LinkedList<>();
+
         private String leftEnd = "";
         private String rightEnd  = "";
         private String defaultLeft = "";
         private String defaultRight = "";
-        private Function<Integer,Color> color = i -> null;
-        private boolean loop = true;
-        private Function<Integer,String> text = i -> null;
-        private BiConsumer<Message, Integer> selection;
-        private Consumer<Message> cancel = (m) -> {};
 
         /**
          * Builds the {@link com.jagrosh.jdautilities.menu.SelectionDialog SelectionDialog}
@@ -266,73 +113,6 @@ public class SelectionDialog extends Menu
 
             return new SelectionDialog(waiter,users,roles,timeout,unit,choices,leftEnd,rightEnd,
                     defaultLeft,defaultRight,color,loop, selection, cancel,text);
-        }
-
-        /**
-         * Sets the {@link java.awt.Color Color} of the {@link net.dv8tion.jda.core.entities.MessageEmbed MessageEmbed}.
-         *
-         * @param  color
-         *         The Color of the MessageEmbed
-         *
-         * @return This builder
-         */
-        public Builder setColor(Color color)
-        {
-            this.color = i -> color;
-            return this;
-        }
-
-        /**
-         * Sets the {@link java.awt.Color Color} of the {@link net.dv8tion.jda.core.entities.MessageEmbed MessageEmbed},
-         * relative to the current selection number as determined by the provided
-         * {@link java.util.function.Function Function}.
-         * <br>As the selection changes, the Function will re-process the current selection number,
-         * allowing for the color of the embed to change depending on the selection number.
-         *
-         * @param  color
-         *         A Function that uses current selection number to get a Color for the MessageEmbed
-         *
-         * @return This builder
-         */
-        public Builder setColor(Function<Integer,Color> color)
-        {
-            this.color = color;
-            return this;
-        }
-
-        /**
-         * Sets the text of the {@link net.dv8tion.jda.core.entities.Message Message} to be displayed
-         * when the {@link com.jagrosh.jdautilities.menu.SelectionDialog SelectionDialog} is built.
-         *
-         * <p>This is displayed directly above the embed.
-         *
-         * @param  text
-         *         The Message content to be displayed above the embed when the SelectionDialog is built
-         *
-         * @return This builder
-         */
-        public Builder setText(String text)
-        {
-            this.text = i -> text;
-            return this;
-        }
-
-        /**
-         * Sets the text of the {@link net.dv8tion.jda.core.entities.Message Message} to be displayed
-         * relative to the current selection number as determined by the provided
-         * {@link java.util.function.Function Function}.
-         * <br>As the selection changes, the Function will re-process the current selection number,
-         * allowing for the displayed text of the Message to change depending on the selection number.
-         *
-         * @param  text
-         *         A Function that uses current selection number to get a text for the Message
-         *
-         * @return This builder
-         */
-        public Builder setText(Function<Integer,String> text)
-        {
-            this.text = text;
-            return this;
         }
 
         /**
@@ -372,90 +152,5 @@ public class SelectionDialog extends Menu
             return this;
         }
 
-        /**
-         * Sets if moving up when at the top selection jumps to the bottom, and visa-versa.
-         *
-         * @param  loop
-         *         {@code true} if pressing up while at the top selection should loop
-         *         to the bottom, {@code false} if it should not
-         *
-         * @return This builder
-         */
-        public Builder useLooping(boolean loop)
-        {
-            this.loop = loop;
-            return this;
-        }
-
-        /**
-         * Sets a {@link java.util.function.BiConsumer BiConsumer} action to perform once a selection is made.
-         * <br>The {@link net.dv8tion.jda.core.entities.Message Message} provided is the one used to display
-         * the menu and the {@link java.lang.Integer Integer} is that of the selection made by the user,
-         * and selections are in order of addition, 1 being the first String choice.
-         *
-         * @param  selection
-         *         A Consumer for the selection. This is one-based indexing.
-         *
-         * @return This builder
-         */
-        public Builder setSelectionConsumer(BiConsumer<Message, Integer> selection)
-        {
-            this.selection = selection;
-            return this;
-        }
-
-        /**
-         * Sets a {@link java.util.function.Consumer Consumer} action to take if the menu is cancelled, either
-         * via the cancel button being used, or if the SelectionDialog times out.
-         *
-         * @param  cancel
-         *         The action to take when the SelectionDialog is cancelled
-         *
-         * @return This builder
-         */
-        public Builder setCanceled(Consumer<Message> cancel)
-        {
-            this.cancel = cancel;
-            return this;
-        }
-
-        /**
-         * Clears the choices to be shown.
-         *
-         * @return This builder
-         */
-        public Builder clearChoices()
-        {
-            this.choices.clear();
-            return this;
-        }
-
-        /**
-         * Sets the String choices to be shown as selections.
-         *
-         * @param  choices
-         *         The String choices to show
-         * @return the builder
-         */
-        public Builder setChoices(String... choices)
-        {
-            this.choices.clear();
-            this.choices.addAll(Arrays.asList(choices));
-            return this;
-        }
-
-        /**
-         * Adds String choices to be shown as selections.
-         *
-         * @param  choices
-         *         The String choices to add
-         *
-         * @return This builder
-         */
-        public Builder addChoices(String... choices)
-        {
-            this.choices.addAll(Arrays.asList(choices));
-            return this;
-        }
     }
 }

--- a/menu/src/main/java/com/jagrosh/jdautilities/menu/SelectionDialog.java
+++ b/menu/src/main/java/com/jagrosh/jdautilities/menu/SelectionDialog.java
@@ -54,6 +54,7 @@ public class SelectionDialog extends Menu
     private final Function<Integer,String> text;
     private final BiConsumer<Message, Integer> success;
     private final Consumer<Message> cancel;
+    private final boolean singleSelectionMode;
     
     public static final String UP = "\uD83D\uDD3C";
     public static final String DOWN = "\uD83D\uDD3D";
@@ -63,7 +64,7 @@ public class SelectionDialog extends Menu
     SelectionDialog(EventWaiter waiter, Set<User> users, Set<Role> roles, long timeout, TimeUnit unit,
                     List<String> choices, String leftEnd, String rightEnd, String defaultLeft, String defaultRight,
                     Function<Integer,Color> color, boolean loop, BiConsumer<Message, Integer> success,
-                    Consumer<Message> cancel, Function<Integer,String> text)
+                    Consumer<Message> cancel, Function<Integer,String> text, boolean singleSelectionMode)
     {
         super(waiter, users, roles, timeout, unit);
         this.choices = choices;
@@ -76,6 +77,20 @@ public class SelectionDialog extends Menu
         this.success = success;
         this.cancel = cancel;
         this.text = text;
+        this.singleSelectionMode = singleSelectionMode;
+    }
+
+    /**
+     * Constructor for backwards compatibility (calls new constructor with singleSelectionMode = false)
+     * @deprecated Use Constructor with extra boolean {@code singleSelectionMode} instead
+     */
+    @Deprecated
+    SelectionDialog(EventWaiter waiter, Set<User> users, Set<Role> roles, long timeout, TimeUnit unit,
+                    List<String> choices, String leftEnd, String rightEnd, String defaultLeft, String defaultRight,
+                    Function<Integer,Color> color, boolean loop, BiConsumer<Message, Integer> success,
+                    Consumer<Message> cancel, Function<Integer,String> text)
+    {
+        this(waiter, users, roles, timeout, unit, choices, leftEnd, rightEnd, defaultLeft, defaultRight, color, loop, success, cancel, text, false);
     }
 
     /**
@@ -192,6 +207,8 @@ public class SelectionDialog extends Menu
                     break;
                 case SELECT:
                     success.accept(message, selection);
+                    if(singleSelectionMode)
+                        return;
                     break;
                 case CANCEL:
                     cancel.accept(message);
@@ -242,6 +259,7 @@ public class SelectionDialog extends Menu
         private Function<Integer,String> text = i -> null;
         private BiConsumer<Message, Integer> selection;
         private Consumer<Message> cancel = (m) -> {};
+        private boolean singleSelectionMode = false;
 
         /**
          * Builds the {@link com.jagrosh.jdautilities.menu.SelectionDialog SelectionDialog}
@@ -265,7 +283,7 @@ public class SelectionDialog extends Menu
             Checks.check(selection != null, "Must provide a selection consumer");
 
             return new SelectionDialog(waiter,users,roles,timeout,unit,choices,leftEnd,rightEnd,
-                    defaultLeft,defaultRight,color,loop, selection, cancel,text);
+                    defaultLeft,defaultRight,color,loop, selection, cancel,text, singleSelectionMode);
         }
 
         /**
@@ -384,6 +402,21 @@ public class SelectionDialog extends Menu
         public Builder useLooping(boolean loop)
         {
             this.loop = loop;
+            return this;
+        }
+
+        /**
+         * Sets if the Menu should exit when a selection was made.
+         * By default, this is false and the menu continues showing choices even after a selection was made.
+         *
+         * @param  singleSelectionMode
+         *         {@code true} if the menu should exit after the first selection being made
+         *
+         * @return This builder
+         */
+        public Builder useSingleSelectionMode(boolean singleSelectionMode)
+        {
+            this.singleSelectionMode = singleSelectionMode;
             return this;
         }
 

--- a/menu/src/main/java/com/jagrosh/jdautilities/menu/SelectionDialog.java
+++ b/menu/src/main/java/com/jagrosh/jdautilities/menu/SelectionDialog.java
@@ -41,6 +41,30 @@ import java.util.function.Function;
  */
 public class SelectionDialog extends SelectionMenu
 {
+    /**
+     * @deprecated Use {@link com.jagrosh.jdautilities.menu.SelectionMenu#UP this} instead
+     */
+    @Deprecated
+    public static final String UP = "\uD83D\uDD3C";
+
+    /**
+     * @deprecated Use {@link com.jagrosh.jdautilities.menu.SelectionMenu#DOWN this} instead
+     */
+    @Deprecated
+    public static final String DOWN = "\uD83D\uDD3D";
+
+    /**
+     * @deprecated Use {@link com.jagrosh.jdautilities.menu.SelectionMenu#SELECT this} instead
+     */
+    @Deprecated
+    public static final String SELECT = "\u2705";
+
+    /**
+     * @deprecated Use {@link com.jagrosh.jdautilities.menu.SelectionMenu#CANCEL this} instead
+     */
+    @Deprecated
+    public static final String CANCEL = "\u274E";
+
     private final String leftEnd, rightEnd;
     private final String defaultLeft, defaultRight;
 
@@ -50,7 +74,8 @@ public class SelectionDialog extends SelectionMenu
                     Function<Integer, Color> color, boolean loop, boolean singleSelectionMode, BiConsumer<Message, Integer> success,
                     Consumer<Message> cancel, Function<Integer,String> text)
     {
-        super(waiter, users, roles, timeout, unit, choices, loop, singleSelectionMode, cancel, color, text, success, Arrays.asList(SELECT, UP, DOWN, CANCEL));
+        super(waiter, users, roles, timeout, unit, choices, loop, singleSelectionMode, cancel, color, text, success,
+            Arrays.asList(SelectionMenu.SELECT, SelectionMenu.UP, SelectionMenu.DOWN, SelectionMenu.CANCEL));
         this.leftEnd = leftEnd;
         this.rightEnd = rightEnd;
         this.defaultLeft = defaultLeft;

--- a/menu/src/main/java/com/jagrosh/jdautilities/menu/SelectionDialog.java
+++ b/menu/src/main/java/com/jagrosh/jdautilities/menu/SelectionDialog.java
@@ -46,12 +46,12 @@ import net.dv8tion.jda.core.utils.Checks;
  */
 public class SelectionDialog extends Menu
 {
-    private final List<String> choices;
+    protected final List<String> choices;
     private final String leftEnd, rightEnd;
     private final String defaultLeft, defaultRight;
-    private final Function<Integer,Color> color;
+    protected final Function<Integer,Color> color;
     private final boolean loop;
-    private final Function<Integer,String> text;
+    protected final Function<Integer,String> text;
     private final BiConsumer<Message, Integer> success;
     private final Consumer<Message> cancel;
     
@@ -206,7 +206,7 @@ public class SelectionDialog extends Menu
         }, timeout, unit, () -> cancel.accept(message));
     }
     
-    private Message render(int selection)
+    protected Message render(int selection)
     {
         StringBuilder sbuilder = new StringBuilder();
         for(int i=0; i<choices.size(); i++)
@@ -226,7 +226,7 @@ public class SelectionDialog extends Menu
 
     /**
      * The {@link com.jagrosh.jdautilities.menu.Menu.Builder Menu.Builder} for
-     * a {@link com.jagrosh.jdautilities.menu.SelectionDialog SelectuibDialog}.
+     * a {@link com.jagrosh.jdautilities.menu.SelectionDialog SelectionDialog}.
      *
      * @author John Grosh
      */
@@ -247,14 +247,14 @@ public class SelectionDialog extends Menu
          * Builds the {@link com.jagrosh.jdautilities.menu.SelectionDialog SelectionDialog}
          * with this Builder.
          *
-         * @return The OrderedMenu built from this Builder.
+         * @return The SelectionDialog built from this Builder.
          *
          * @throws java.lang.IllegalArgumentException
          *         If one of the following is violated:
          *         <ul>
          *             <li>No {@link com.jagrosh.jdautilities.commons.waiter.EventWaiter EventWaiter} was set.</li>
          *             <li>No choices were set.</li>
-         *             <li>No action {@link java.util.function.Consumer Consumer} was set.</li>
+         *             <li>No action {@link java.util.function.BiConsumer BiConsumer} was set.</li>
          *         </ul>
          */
         @Override

--- a/menu/src/main/java/com/jagrosh/jdautilities/menu/SelectionMenu.java
+++ b/menu/src/main/java/com/jagrosh/jdautilities/menu/SelectionMenu.java
@@ -1,0 +1,408 @@
+package com.jagrosh.jdautilities.menu;
+
+import com.jagrosh.jdautilities.commons.waiter.EventWaiter;
+import net.dv8tion.jda.core.Permission;
+import net.dv8tion.jda.core.entities.*;
+import net.dv8tion.jda.core.events.message.react.MessageReactionAddEvent;
+import net.dv8tion.jda.core.requests.RestAction;
+
+import java.awt.Color;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+/**
+ * https://www.github.com/JohnnyJayJay
+ * @author Johnny_JayJay
+ */
+public abstract class SelectionMenu extends Menu
+{
+
+    public static final String UP = "\uD83D\uDD3C";
+    public static final String DOWN = "\uD83D\uDD3D";
+    public static final String SELECT = "\u2705";
+    public static final String CANCEL = "\u274E";
+
+    protected final boolean loop;
+    protected final List<String> choices;
+    protected final BiConsumer<Message, Integer> success;
+    protected final Consumer<Message> cancel;
+    protected final Function<Integer, Color> colorFunction;
+    protected final Function<Integer, String> textFunction;
+
+    private final List<String> reactions;
+
+
+    protected SelectionMenu(EventWaiter waiter, Set<User> users, Set<Role> roles, long timeout, TimeUnit unit,
+                            List<String> choices, boolean loop, Consumer<Message> cancel, Function<Integer, Color> colorFunction,
+                            Function<Integer, String> textFunction, BiConsumer<Message, Integer> success, List<String> reactions)
+    {
+        super(waiter, users, roles, timeout, unit);
+        this.choices = choices;
+        this.loop = loop;
+        this.cancel = cancel;
+        this.colorFunction = colorFunction;
+        this.textFunction = textFunction;
+        this.success = success;
+        this.reactions = reactions;
+    }
+
+    /**
+     * Shows the SelectionMenu as a new {@link net.dv8tion.jda.core.entities.Message Message}
+     * in the provided {@link net.dv8tion.jda.core.entities.MessageChannel MessageChannel}, starting with
+     * the first selection.
+     *
+     * @param  channel
+     *         The MessageChannel to send the new Message to
+     */
+    @Override
+    public void display(MessageChannel channel)
+    {
+        showDialog(channel, 1);
+    }
+
+    /**
+     * Displays this SelectionMenu by editing the provided
+     * {@link net.dv8tion.jda.core.entities.Message Message}, starting with the first selection.
+     *
+     * @param  message
+     *         The Message to display the Menu in
+     */
+    @Override
+    public void display(Message message)
+    {
+        showDialog(message, 1);
+    }
+
+    /**
+     * Shows the SelectionMenu as a new {@link net.dv8tion.jda.core.entities.Message Message}
+     * in the provided {@link net.dv8tion.jda.core.entities.MessageChannel MessageChannel}, starting with
+     * the number selection provided.
+     *
+     * @param  channel
+     *         The MessageChannel to send the new Message to
+     * @param  selection
+     *         The number selection to start on
+     */
+    public void showDialog(MessageChannel channel, int selection)
+    {
+        if(selection<1)
+            selection = 1;
+        else if(selection>choices.size())
+            selection = choices.size();
+        Message msg = render(selection);
+        initialize(channel.sendMessage(msg), selection);
+    }
+
+    /**
+     * Displays this SelectionMenu by editing the provided
+     * {@link net.dv8tion.jda.core.entities.Message Message}, starting with the number selection
+     * provided.
+     *
+     * @param  message
+     *         The Message to display the Menu in
+     * @param  selection
+     *         The number selection to start on
+     */
+    public void showDialog(Message message, int selection)
+    {
+        if(selection<1)
+            selection = 1;
+        else if(selection>choices.size())
+            selection = choices.size();
+        Message msg = render(selection);
+        initialize(message.editMessage(msg), selection);
+    }
+
+    private void initialize(RestAction<Message> action, int selection)
+    {
+        action.queue(m -> {
+            if(choices.size()>1)
+            {
+                reactions.forEach((s) -> m.addReaction(s).queue());
+            }
+            else
+            {
+                m.addReaction(SELECT).queue();
+                m.addReaction(CANCEL).queue(v -> selectionDialog(m, selection), v -> selectionDialog(m, selection));
+            }
+        });
+    }
+
+    private void selectionDialog(Message message, int selection)
+    {
+        waiter.waitForEvent(MessageReactionAddEvent.class, event ->
+            event.getMessageIdLong() == message.getIdLong()
+            && reactions.contains(event.getReactionEmote().getName())
+            && isValidUser(event.getUser()),
+            event -> {
+
+            // get the new selection based on the emoji and the current selection
+            int newSelection = getNewSelection(message, event.getReactionEmote().getName(), selection);
+
+            // no new selection should be made (e.g. if the user cancelled)
+            if (newSelection == -1)
+                return;
+
+            // if this is on a guild and the self member has permission to, remove the reaction
+            Guild guild = event.getGuild();
+            if (guild != null && guild.getSelfMember().hasPermission(event.getTextChannel(), Permission.MESSAGE_MANAGE))
+                event.getReaction().removeReaction(event.getUser()).queue();
+
+            message.editMessage(render(newSelection)).queue(m -> selectionDialog(m, newSelection)); // display new selection and wait for the next one
+        }, timeout, unit, () -> cancel.accept(message));
+    }
+
+    /**
+     * Evaluates the next selection based on the previous one and the emoji reacted with.
+     * <br>This handles the default reactions (UP, DOWN, SELECT, CANCEL), but may be overwritten
+     * for additional reactions used by an implementation of this class.
+     *
+     * @param  message
+     *         The {@link net.dv8tion.jda.core.entities.Message Message} this menu is being displayed in
+     *
+     * @param  emoji
+     *         The emoji the user reacted with (in unicode)
+     *
+     * @param  selection
+     *         The previous selection (before they reacted)
+     *
+     * @return A new selection that may differ from this default method
+     */
+    protected int getNewSelection(Message message, String emoji, int selection)
+    {
+        switch(emoji)
+        {
+            case UP:
+                if(selection>1)
+                    selection--;
+                else if(loop)
+                    selection = choices.size();
+                break;
+            case DOWN:
+                if(selection<choices.size())
+                    selection++;
+                else if(loop)
+                    selection = 1;
+                break;
+            case SELECT:
+                success.accept(message, selection);
+                break;
+            case CANCEL:
+                cancel.accept(message);
+                return -1;
+        }
+
+        return selection;
+    }
+
+    /**
+     * A method to overwrite when making implementations of this abstract class.
+     * <br>This method provides the message to be displayed based on the current selection of this Menu.
+     *
+     * @param  selection
+     *         The currently selected choice. This is always 1 more than the corresponding index of the {@code choices}-List.
+     *         E.g.: when the last entry is selected, {@code selection = choices.size()}.
+     *
+     * @return The {@link net.dv8tion.jda.core.entities.Message Message} to be displayed
+     */
+    protected abstract Message render(int selection);
+
+    /**
+     * An extendable frame for a chain-method builder that constructs a specified type of
+     * {@link com.jagrosh.jdautilities.menu.SelectionMenu SelectionMenu}.<p>
+     *
+     * Every extension of this class should have a nested class
+     * <br>{@literal public static class Builder extends SelectionMenu.Builder<Builder, MySelectionMenu>}.
+     *
+     * @param  <T>
+     *         The Builder type. Usually, this is just the type of this Builder's extension.
+     *
+     * @param  <V>
+     *         The {@link com.jagrosh.jdautilities.menu.SelectionMenu SelectionMenu} to be built.
+     *         Usually, this is the enclosing class of this Builder.
+     */
+    @SuppressWarnings("unchecked")
+    public abstract static class Builder<T extends Builder<T, V>, V extends SelectionMenu> extends Menu.Builder<T, V>
+    {
+        protected final List<String> choices = new ArrayList<>();
+
+        protected boolean loop = true;
+        protected Function<Integer, String> text = (i) -> null;
+        protected Function<Integer, Color> color = (i) -> null;
+        protected BiConsumer<Message, Integer> selection = (m, i) -> {};
+        protected Consumer<Message> cancel = (m) -> {};
+
+
+        /**
+         * Sets the {@link java.awt.Color Color} of the {@link net.dv8tion.jda.core.entities.MessageEmbed MessageEmbed}.
+         *
+         * @param  color
+         *         The Color of the MessageEmbed
+         *
+         * @return This builder
+         */
+        public T setColor(Color color)
+        {
+            this.color = i -> color;
+            return (T) this;
+        }
+
+        /**
+         * Sets the {@link java.awt.Color Color} of the {@link net.dv8tion.jda.core.entities.MessageEmbed MessageEmbed},
+         * relative to the current selection number as determined by the provided
+         * {@link java.util.function.Function Function}.
+         * <br>As the selection changes, the Function will re-process the current selection number,
+         * allowing for the color of the embed to change depending on the selection number.
+         *
+         * @param  color
+         *         A Function that uses current selection number to get a Color for the MessageEmbed
+         *
+         * @return This builder
+         */
+        public T setColor(Function<Integer, Color> color)
+        {
+            this.color = color;
+            return (T) this;
+        }
+
+        /**
+         * Sets the text of the {@link net.dv8tion.jda.core.entities.Message Message} to be displayed
+         * when the {@link com.jagrosh.jdautilities.menu.SelectionDialog SelectionDialog} is built.
+         *
+         * <p>This is displayed directly above the embed.
+         *
+         * @param  text
+         *         The Message content to be displayed above the embed when the SelectionDialog is built
+         *
+         * @return This builder
+         */
+        public T setText(String text)
+        {
+            this.text = i -> text;
+            return (T) this;
+        }
+
+        /**
+         * Sets the text of the {@link net.dv8tion.jda.core.entities.Message Message} to be displayed
+         * relative to the current selection number as determined by the provided
+         * {@link java.util.function.Function Function}.
+         * <br>As the selection changes, the Function will re-process the current selection number,
+         * allowing for the displayed text of the Message to change depending on the selection number.
+         *
+         * @param  text
+         *         A Function that uses current selection number to get a text for the Message
+         *
+         * @return This builder
+         */
+        public T setText(Function<Integer, String> text)
+        {
+            this.text = text;
+            return (T) this;
+        }
+
+        /**
+         * Sets if moving up when at the top selection jumps to the bottom, and visa-versa.
+         *
+         * @param  loop
+         *         {@code true} if pressing up while at the top selection should loop
+         *         to the bottom, {@code false} if it should not
+         *
+         * @return This builder
+         */
+        public T useLooping(boolean loop)
+        {
+            this.loop = loop;
+            return (T) this;
+        }
+
+        /**
+         * Sets a {@link java.util.function.BiConsumer BiConsumer} action to perform once a selection is made.
+         * <br>The {@link net.dv8tion.jda.core.entities.Message Message} provided is the one used to display
+         * the menu and the {@link java.lang.Integer Integer} is that of the selection made by the user,
+         * and selections are in order of addition, 1 being the first String choice.
+         *
+         * @param  selection
+         *         A Consumer for the selection. This is one-based indexing.
+         *
+         * @return This builder
+         */
+        public T setSelectionConsumer(BiConsumer<Message, Integer> selection)
+        {
+            this.selection = selection;
+            return (T) this;
+        }
+
+        /**
+         * Sets a {@link java.util.function.Consumer Consumer} action to take if the menu is cancelled, either
+         * via the cancel button being used, or if the SelectionDialog times out.
+         *
+         * @param  cancel
+         *         The action to take when the SelectionDialog is cancelled
+         *
+         * @return This builder
+         */
+        public T setCanceled(Consumer<Message> cancel)
+        {
+            this.cancel = cancel;
+            return (T) this;
+        }
+
+        /**
+         * Clears the choices to be shown.
+         *
+         * @return This builder
+         */
+        public T clearChoices()
+        {
+            this.choices.clear();
+            return (T) this;
+        }
+
+        /**
+         * Sets the String choices to be shown as selections.
+         *
+         * @param  choices
+         *         The String choices to show
+         * @return This builder
+         */
+        public T setChoices(List<String> choices)
+        {
+            this.choices.clear();
+            this.choices.addAll(choices);
+            return (T) this;
+        }
+
+        /**
+         * Sets the String choices to be shown as selections.
+         *
+         * @param  choices
+         *         The String choices to show
+         * @return This builder
+         */
+        public T setChoices(String... choices)
+        {
+            return this.setChoices(Arrays.asList(choices));
+        }
+
+        /**
+         * Adds String choices to be shown as selections.
+         *
+         * @param  choices
+         *         The String choices to add
+         *
+         * @return This builder
+         */
+        public T addChoices(String... choices)
+        {
+            this.choices.addAll(Arrays.asList(choices));
+            return (T) this;
+        }
+
+    }
+}

--- a/menu/src/main/java/com/jagrosh/jdautilities/menu/SelectionMenu.java
+++ b/menu/src/main/java/com/jagrosh/jdautilities/menu/SelectionMenu.java
@@ -2,8 +2,13 @@ package com.jagrosh.jdautilities.menu;
 
 import com.jagrosh.jdautilities.commons.waiter.EventWaiter;
 import net.dv8tion.jda.core.Permission;
-import net.dv8tion.jda.core.entities.*;
+import net.dv8tion.jda.core.entities.Guild;
+import net.dv8tion.jda.core.entities.Message;
+import net.dv8tion.jda.core.entities.MessageChannel;
+import net.dv8tion.jda.core.entities.Role;
+import net.dv8tion.jda.core.entities.User;
 import net.dv8tion.jda.core.events.message.react.MessageReactionAddEvent;
+import net.dv8tion.jda.core.requests.RequestFuture;
 import net.dv8tion.jda.core.requests.RestAction;
 
 import java.awt.Color;
@@ -15,6 +20,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * A {@link com.jagrosh.jdautilities.menu.Menu Menu} extension made for menus that provides
@@ -146,7 +152,8 @@ public abstract class SelectionMenu extends Menu
         action.queue(m -> {
             if(choices.size()>1)
             {
-                reactions.forEach((s) -> m.addReaction(s).queue());
+                RequestFuture.allOf(reactions.stream().map((s) -> m.addReaction(s).submit()).collect(Collectors.toList()))
+                    .thenAccept((v) -> selectionDialog(m, selection));
             }
             else
             {


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing
[pull-request]: https://github.com/JDA-Applications/JDA-Utilities/pulls

## Pull Request

#### Pull Request Checklist
Please follow the following steps before opening this PR.<br>
PRs that do not complete the checklist will be subject to denial for
missing information.

- [x] I have checked the [pull request page][pull-request] for upcoming
      or merged features/bug fixes.
- [x] I have read JDA's [contributing guidelines][contributing].

#### Pull Request Information
Check and fill in the blanks for all that apply:

- [ ] My PR fixes a bug, error, or other issue with the library's codebase.
- [x] My PR is for the `menu` module of the JDA-Utilities library.
- [ ] My PR creates a new module for the JDA-Utilities library: `______`.

#### Description

This PR re-structures the SelectionDialog.
There is a new abstract class called `SelectionMenu` that allows easier implementations for menus with selections. The code for `SelectionMenu` is mainly taken from the former `SelectionDialog`, as every `SelectionMenu` basically works like it.
 
When making new extensions of `SelectionMenu`, the only difference should be the Builder and the `render(int)` method, which is declared abstract in `SelectionMenu`. It is also possible to overwrite the new method `getNewSelection(Message, String, int)` for other possible reactions. Configuring the reactions is not up to the user yet, however you have to pass a List of Strings (the unicode emojis) to the `SelectionMenu` constructor to set the reactions that are available. Currently, this is done internally.

In this PR, a new `SelectionMenu` is already included: the `ScrollSelection`.
The `ScrollSelection` is similar to `SelectionDialog`, but it only shows the currently selected entry. Also, the content of the embed description is configurable with a format String.

I also added a new method for all `SelectionMenu` Builders, `setChoices(List<String>)`.

The contents of [Kantenkugel's recent PR](https://github.com/JDA-Applications/JDA-Utilities/pull/75) are also included and function correctly. 

All of this is fully mergeable with the current master branch. Existing code will still work, too. 
~~, with one exception: The `public static final String`s in `SelectionDialog` are gone, they are now in `SelectionMenu`. They can still be added again and immediately deprecated to avoid any inconvenience~~.
Update: Added them again for convenience
