### PR TITLE
Add message attribute to onTerminatedCommand

### DIFF
--- a/command/src/main/java/com/jagrosh/jdautilities/command/Command.java
+++ b/command/src/main/java/com/jagrosh/jdautilities/command/Command.java
@@ -536,7 +536,7 @@ public abstract class Command
         if(message!=null)
             event.reply(message);
         if(event.getClient().getListener()!=null)
-            event.getClient().getListener().onTerminatedCommand(event, this);
+            event.getClient().getListener().onTerminatedCommand(event, this, message);
     }
 
     /**

--- a/command/src/main/java/com/jagrosh/jdautilities/command/CommandListener.java
+++ b/command/src/main/java/com/jagrosh/jdautilities/command/CommandListener.java
@@ -61,8 +61,10 @@ public interface CommandListener
      *         The CommandEvent that triggered the Command
      * @param  command
      *         The Command that was triggered
+     * @param  message
+     *         The message why it was terminated
      */
-    default void onTerminatedCommand(CommandEvent event, Command command) {}
+    default void onTerminatedCommand(CommandEvent event, Command command, String message) {}
     
     /**
      * Called when a {@link net.dv8tion.jda.core.events.message.MessageReceivedEvent MessageReceivedEvent}


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing
[pull-request]: https://github.com/JDA-Applications/JDA-Utilities/pulls

## Pull Request

#### Pull Request Checklist
Please follow the following steps before opening this PR.<br>
PRs that do not complete the checklist will be subject to denial for
missing information.

- [x] I have checked the [pull request page][pull-request] for upcoming
      or merged features/bug fixes.
- [x] I have read JDA's [contributing guidelines][contributing].

#### Pull Request Information
Check and fill in the blanks for all that apply:

- [ ] My PR fixes a bug, error, or other issue with the library's codebase.
- [x] My PR is for the `command` module of the JDA-Utilities library.
- [ ] My PR creates a new module for the JDA-Utilities library: `______`.

#### Description
To handle the onTerminatedCommand event in a custom CommandListener it would be nice to have access to message attribute which was passed to the  `terminate(CommandEvent event, String message)` method.
