### PR TITLE
Allow Terminations To Reply In Dms

### DIFF
--- a/command/src/main/java/com/jagrosh/jdautilities/command/Command.java
+++ b/command/src/main/java/com/jagrosh/jdautilities/command/Command.java
@@ -15,14 +15,15 @@
  */
 package com.jagrosh.jdautilities.command;
 
-import java.util.Arrays;
-import java.util.Objects;
-import java.util.function.BiConsumer;
-import java.util.function.Predicate;
 import net.dv8tion.jda.core.Permission;
 import net.dv8tion.jda.core.entities.ChannelType;
 import net.dv8tion.jda.core.entities.TextChannel;
 import net.dv8tion.jda.core.entities.VoiceChannel;
+
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.function.BiConsumer;
+import java.util.function.Predicate;
 
 /**
  * <h1><b>Commands In JDA-Utilities</b></h1>
@@ -154,6 +155,12 @@ public abstract class Command
      * <br>Default {@code false}
      */
     protected boolean hidden = false;
+
+    /**
+     * {@code true} if this command should reply in dms when terminated.
+     * <br>Default {@code false}
+     */
+    protected boolean terminateInDms = false;
 
     /**
      * The {@link com.jagrosh.jdautilities.command.Command.CooldownScope CooldownScope}
@@ -531,10 +538,25 @@ public abstract class Command
         return hidden;
     }
 
+    /**
+     * Checks whether or not this command should reply in dms upon termination
+     *
+     * @return {@code true} if the command should reply in dms, otherwise {@code false}
+     */
+    public boolean isTerminatingInDms()
+    {
+        return terminateInDms;
+    }
+
     private void terminate(CommandEvent event, String message)
     {
         if(message!=null)
-            event.reply(message);
+            if (terminateInDms) {
+                event.replyInDm(message);
+            } else {
+                event.reply(message);
+            }
+
         if(event.getClient().getListener()!=null)
             event.getClient().getListener().onTerminatedCommand(event, this);
     }

--- a/command/src/main/java/com/jagrosh/jdautilities/command/CommandBuilder.java
+++ b/command/src/main/java/com/jagrosh/jdautilities/command/CommandBuilder.java
@@ -15,8 +15,8 @@
  */
 package com.jagrosh.jdautilities.command;
 
-import com.jagrosh.jdautilities.command.Command.*;
-
+import com.jagrosh.jdautilities.command.Command.Category;
+import com.jagrosh.jdautilities.command.Command.CooldownScope;
 import net.dv8tion.jda.core.Permission;
 
 import java.util.Collection;
@@ -56,6 +56,7 @@ public class CommandBuilder
     private boolean usesTopicTags = true;
     private CooldownScope cooldownScope = CooldownScope.USER;
     private boolean hidden = false;
+    private boolean terminateInDms;
 
     /**
      * Sets the {@link com.jagrosh.jdautilities.command.Command#name name}
@@ -451,6 +452,23 @@ public class CommandBuilder
     }
 
     /**
+     * Sets the Command built to {@link com.jagrosh.jdautilities.command.Command#terminateInDms when
+     * an error occurs.
+     *
+     *
+     * @param  terminateInDms
+     *         {@code true} if the Command built is replying in dms upon termination, {@code false} if it will not.
+     *
+     * @return This CommandBuilder
+     */
+
+    public CommandBuilder setTerminatingInDms(boolean terminateInDms)
+    {
+        this.terminateInDms = terminateInDms;
+        return this;
+    }
+
+    /**
      * Builds the {@link com.jagrosh.jdautilities.command.Command Command}
      * using the previously provided information.
      *
@@ -492,7 +510,7 @@ public class CommandBuilder
                 guildOnly, requiredRole, ownerCommand, cooldown,
                 userPermissions, botPermissions, aliases.toArray(new String[aliases.size()]),
                 children.toArray(new Command[children.size()]), helpBiConsumer, usesTopicTags,
-                cooldownScope, hidden)
+                cooldownScope, hidden, terminateInDms)
         {
             @Override
             protected void execute(CommandEvent event)
@@ -509,7 +527,7 @@ public class CommandBuilder
                      boolean ownerCommand, int cooldown, Permission[] userPermissions,
                      Permission[] botPermissions, String[] aliases, Command[] children,
                      BiConsumer<CommandEvent, Command> helpBiConsumer,
-                     boolean usesTopicTags, CooldownScope cooldownScope, boolean hidden)
+                     boolean usesTopicTags, CooldownScope cooldownScope, boolean hidden, boolean terminateInDms)
         {
             this.name = name;
             this.help = help;
@@ -527,6 +545,7 @@ public class CommandBuilder
             this.usesTopicTags = usesTopicTags;
             this.cooldownScope = cooldownScope;
             this.hidden = hidden;
+            this.terminateInDms = terminateInDms;
         }
     }
 }

--- a/command/src/main/java/com/jagrosh/jdautilities/command/CommandBuilder.java
+++ b/command/src/main/java/com/jagrosh/jdautilities/command/CommandBuilder.java
@@ -56,7 +56,7 @@ public class CommandBuilder
     private boolean usesTopicTags = true;
     private CooldownScope cooldownScope = CooldownScope.USER;
     private boolean hidden = false;
-    private boolean terminateInDms;
+    private boolean terminateInDms = false;
 
     /**
      * Sets the {@link com.jagrosh.jdautilities.command.Command#name name}


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing
[pull-request]: https://github.com/JDA-Applications/JDA-Utilities/pulls

## Pull Request

#### Pull Request Checklist
Please follow the following steps before opening this PR.<br>
PRs that do not complete the checklist will be subject to denial for
missing information.

- [x] I have checked the [pull request page][pull-request] for upcoming
      or merged features/bug fixes.
- [x] I have read JDA's [contributing guidelines][contributing].

#### Pull Request Information
Check and fill in the blanks for all that apply:

- [x] My PR is for the `Command` module of the JDA-Utilities library.

#### Description

If a User does not have the requested Permissions, event.reply() will be called automatically by JDA-Utils which sends the Error Message to the Channel. I would like that the User gets it via. PM to reduce the Spam. So I propose a setting determining whether or not a User should be PMed.
