### PR TITLE
Correcting typo in OrderedMenu.Builder

### DIFF
--- a/menu/src/main/java/com/jagrosh/jdautilities/menu/OrderedMenu.java
+++ b/menu/src/main/java/com/jagrosh/jdautilities/menu/OrderedMenu.java
@@ -412,7 +412,7 @@ public class OrderedMenu extends Menu
 
         /**
          * Sets the builder to build an {@link com.jagrosh.jdautilities.menu.OrderedMenu OrderedMenu}
-         * using numbers for ordering and reactions (IE: A, B, C, etc.).
+         * using numbers for ordering and reactions (IE: 1, 2, 3, etc.).
          *
          * @return This builder
          */


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing
[pull-request]: https://github.com/JDA-Applications/JDA-Utilities/pulls

## Pull Request

#### Pull Request Checklist
Please follow the following steps before opening this PR.<br>
PRs that do not complete the checklist will be subject to denial for
missing information.

- [x] I have checked the [pull request page][pull-request] for upcoming
      or merged features/bug fixes.
- [x] I have read JDA's [contributing guidelines][contributing].

#### Pull Request Information
Check and fill in the blanks for all that apply:

- [x] My PR fixes a bug, error, or other issue with the library's codebase.
- [x] My PR is for the `menu` module of the JDA-Utilities library.
- [ ] My PR creates a new module for the JDA-Utilities library: `______`.

#### Description

This is a small PR that corrects a small description error in `useNumbers()` which gives `(A, B, C, etc.)` as example instead of `(1, 2, 3, etc,)`