### PR TITLE
Add check for if in non-guild channel in Menu Module

### DIFF
--- a/menu/src/main/java/com/jagrosh/jdautilities/menu/OrderedMenu.java
+++ b/menu/src/main/java/com/jagrosh/jdautilities/menu/OrderedMenu.java
@@ -279,7 +279,7 @@ public class OrderedMenu extends Menu
         if(!e.getMessageId().equals(m.getId()))
             return false;
         // The user is not valid
-        if(!isValidUser(e.getUser(), e.getChannelType() == ChannelType.Private ? null : e.getGuild()))
+        if(!isValidUser(e.getUser(), event.isFromGuild() ? event.getGuild() : null)))
             return false;
         // The reaction is the cancel reaction
         if(e.getReaction().getReactionEmote().getName().equals(CANCEL))

--- a/menu/src/main/java/com/jagrosh/jdautilities/menu/OrderedMenu.java
+++ b/menu/src/main/java/com/jagrosh/jdautilities/menu/OrderedMenu.java
@@ -279,7 +279,7 @@ public class OrderedMenu extends Menu
         if(!e.getMessageId().equals(m.getId()))
             return false;
         // The user is not valid
-        if(!isValidUser(e.getUser(), event.isFromGuild() ? event.getGuild() : null)))
+        if(!isValidUser(e.getUser(), e.isFromGuild() ? e.getGuild() : null))
             return false;
         // The reaction is the cancel reaction
         if(e.getReaction().getReactionEmote().getName().equals(CANCEL))

--- a/menu/src/main/java/com/jagrosh/jdautilities/menu/OrderedMenu.java
+++ b/menu/src/main/java/com/jagrosh/jdautilities/menu/OrderedMenu.java
@@ -279,7 +279,7 @@ public class OrderedMenu extends Menu
         if(!e.getMessageId().equals(m.getId()))
             return false;
         // The user is not valid
-        if(!isValidUser(e.getUser(), e.getGuild()))
+        if(!isValidUser(e.getUser(), e.getChannelType() == ChannelType.Private ? null : e.getGuild()))
             return false;
         // The reaction is the cancel reaction
         if(e.getReaction().getReactionEmote().getName().equals(CANCEL))


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing
[pull-request]: https://github.com/JDA-Applications/JDA-Utilities/pulls

## Pull Request

#### Pull Request Checklist
Please follow the following steps before opening this PR.<br>
PRs that do not complete the checklist will be subject to denial for
missing information.

- [x] I have checked the [pull request page][pull-request] for upcoming
      or merged features/bug fixes.
- [x] I have read JDA's [contributing guidelines][contributing].

#### Pull Request Information
Check and fill in the blanks for all that apply:

- [x] My PR fixes a bug, error, or other issue with the library's codebase.
- [x] My PR is for the `menu` module of the JDA-Utilities library.
- [ ] My PR creates a new module for the JDA-Utilities library: `______`.

#### Description

JDA throws an error if you attempt to .getGuild() on a MessageReceivedEvent where no guild is defined (i.e. a Private Channel/DM).
This adds a check for if getGuild() should be queried at all.
