### PR TITLE
Fixes for cooldown handling

### DIFF
--- a/command/src/main/java/com/jagrosh/jdautilities/command/Command.java
+++ b/command/src/main/java/com/jagrosh/jdautilities/command/Command.java
@@ -310,12 +310,8 @@ public abstract class Command
             int remaining = event.getClient().getRemainingCooldown(key);
             if(remaining>0)
             {
-                String error = getCooldownError(event, remaining);
-                if(error!=null)
-                {
-                    terminate(event, error);
-                    return;
-                }
+                terminate(event, getCooldownError(event, remaining));
+                return;
             }
             else event.getClient().applyCooldown(key, cooldown);
         }

--- a/command/src/main/java/com/jagrosh/jdautilities/command/impl/CommandClientImpl.java
+++ b/command/src/main/java/com/jagrosh/jdautilities/command/impl/CommandClientImpl.java
@@ -213,7 +213,7 @@ public class CommandClientImpl implements CommandClient, EventListener
     {
         if(cooldowns.containsKey(name))
         {
-            int time = (int)OffsetDateTime.now().until(cooldowns.get(name), ChronoUnit.SECONDS);
+            int time = (int) Math.ceil(OffsetDateTime.now().until(cooldowns.get(name), ChronoUnit.MILLIS) / 1000D);
             if(time<=0)
             {
                 cooldowns.remove(name);


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing
[pull-request]: https://github.com/JDA-Applications/JDA-Utilities/pulls

## Pull Request

#### Pull Request Checklist
Please follow the following steps before opening this PR.<br>
PRs that do not complete the checklist will be subject to denial for
missing information.

- [x] I have checked the [pull request page][pull-request] for upcoming
      or merged features/bug fixes.
- [x] I have read JDA's [contributing guidelines][contributing].

#### Pull Request Information
Check and fill in the blanks for all that apply:

- [x] My PR fixes a bug, error, or other issue with the library's codebase.
- [x] My PR is for the `command` module of the JDA-Utilities library.
- [ ] My PR creates a new module for the JDA-Utilities library: `______`.

#### Description

This PR adds 2 fixes to the cooldown handling:

##### Cooldowns are now properly rounded up

Up until now, `CommandClient#getRemainingCooldown()` returns the rounded down amount of seconds remaining, which results in cooldowns effectively being (almost) 1 second shorter than they should be: 
If 1 second cooldown is set, then at the next check (lets assume 990ms cooldown left), `getRemainingCooldown()` would return 0, which in turn allows the command to be executed again.

By fetching the amount of ms remaining and rounding that up to the next second, this PR attemts to fix that issue.

##### Allows for disabling of cooldown error message

Now it is possible to override `Command#getCooldownError()` and return `null` in order to disable cooldown error messages to be sent