### PR TITLE
Make JDA Utils only set Activity when set.

### DIFF
--- a/command/src/main/java/com/jagrosh/jdautilities/command/CommandClientBuilder.java
+++ b/command/src/main/java/com/jagrosh/jdautilities/command/CommandClientBuilder.java
@@ -223,7 +223,7 @@ public class CommandClientBuilder
 
     /**
      * Sets the {@link net.dv8tion.jda.api.entities.Activity Game} to use when the bot is ready.
-     * <br>Can be set to {@code null} for no activity.
+     * <br>Can be set to {@code null} for JDA Utilities to not set it.
      * 
      * @param  activity
      *         The Game to use when the bot is ready

--- a/command/src/main/java/com/jagrosh/jdautilities/command/impl/CommandClientImpl.java
+++ b/command/src/main/java/com/jagrosh/jdautilities/command/impl/CommandClientImpl.java
@@ -474,11 +474,9 @@ public class CommandClientImpl implements CommandClient, EventListener
         }
         textPrefix = prefix.equals(DEFAULT_PREFIX) ? "@"+event.getJDA().getSelfUser().getName()+" " : prefix;
         
-        if(status != null)
-            event.getJDA.getPresence().setOnlineStatus(status);
-            
-        event.getJDA().getPresence().setPresence(status==null ? OnlineStatus.ONLINE : status, 
-                activity ==null ? null : "default".equals(activity.getName()) ? Activity.playing("Type "+textPrefix+helpWord) : activity);
+        if(activity != null) 
+            event.getJDA().getPresence().setPresence(status==null ? OnlineStatus.ONLINE : status, 
+                "default".equals(activity.getName()) ? Activity.playing("Type "+textPrefix+helpWord) : activity);
 
         // Start SettingsManager if necessary
         GuildSettingsManager<?> manager = getSettingsManager();

--- a/command/src/main/java/com/jagrosh/jdautilities/command/impl/CommandClientImpl.java
+++ b/command/src/main/java/com/jagrosh/jdautilities/command/impl/CommandClientImpl.java
@@ -473,6 +473,10 @@ public class CommandClientImpl implements CommandClient, EventListener
             return;
         }
         textPrefix = prefix.equals(DEFAULT_PREFIX) ? "@"+event.getJDA().getSelfUser().getName()+" " : prefix;
+        
+        if(status != null)
+            event.getJDA.getPresence().setOnlineStatus(status);
+            
         event.getJDA().getPresence().setPresence(status==null ? OnlineStatus.ONLINE : status, 
                 activity ==null ? null : "default".equals(activity.getName()) ? Activity.playing("Type "+textPrefix+helpWord) : activity);
 


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing
[pull-request]: https://github.com/JDA-Applications/JDA-Utilities/pulls

## Pull Request

#### Pull Request Checklist
Please follow the following steps before opening this PR.<br>
PRs that do not complete the checklist will be subject to denial for
missing information.

- [x] I have checked the [pull request page][pull-request] for upcoming
      or merged features/bug fixes.
- [x] I have read JDA's [contributing guidelines][contributing].

#### Pull Request Information
Check and fill in the blanks for all that apply:

- [x] My PR fixes a bug, error, or other issue with the library's codebase.
- [x] My PR is for the `command` module of the JDA-Utilities library.
- [ ] My PR creates a new module for the JDA-Utilities library: `______`.

#### Description
By default does JDA Utilities set the Activity no matter what.
When providing `null` does it still set the activity which results in no activity being set at all.

This is annoying, especially considering that this is done in the ReadyEvent and could have conflicts with bots that also set the Activity on the ReadyEvent.

This PR adds a simple check, that will JDA Utils only set the Activity when the provided activity isn't null.
This allows the usage of the Command package while still using their own method(s) to set a bots activity.
