### PR TITLE
Add an event inverter utility class

### DIFF
--- a/commons/src/main/java/com/jagrosh/jdautilities/commons/utils/InverseAction.java
+++ b/commons/src/main/java/com/jagrosh/jdautilities/commons/utils/InverseAction.java
@@ -3,6 +3,7 @@ package com.jagrosh.jdautilities.commons.utils;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Role;
+import net.dv8tion.jda.api.entities.VoiceChannel;
 import net.dv8tion.jda.api.events.channel.category.CategoryCreateEvent;
 import net.dv8tion.jda.api.events.channel.category.update.CategoryUpdateNameEvent;
 import net.dv8tion.jda.api.events.channel.category.update.CategoryUpdatePositionEvent;
@@ -163,33 +164,43 @@ public final class InverseAction
     /**
      * @return An attempt to undeafen if they were deafened, or an attempt to deafen if they were undeafened
      */
-    public static RestAction<?> of(GuildVoiceGuildDeafenEvent event)
+    public static RestAction<Void> of(GuildVoiceGuildDeafenEvent event)
     {
-        return null;
+        return event.getGuild().leave();
     }
 
     /**
      * @return An attempt to kick them from the channel
      */
-    public static RestAction<?> of(GuildVoiceJoinEvent event)
+    public static RestAction<Void> of(GuildVoiceJoinEvent event)
     {
-        return null;
+        Guild guild = event.getGuild();
+        Member member = event.getMember();
+
+        return guild.kickVoiceMember(member);
     }
 
     /**
      * @return An attempt to move them back to where they just were
      */
-    public static RestAction<?> of(GuildVoiceMoveEvent event)
+    public static RestAction<Void> of(GuildVoiceMoveEvent event)
     {
-        return null;
+        Guild guild = event.getGuild();
+        Member member = event.getMember();
+        VoiceChannel previous = event.getOldValue();
+
+        return guild.moveVoiceMember(member, previous);
     }
 
     /**
      * @return An attempt to unmute if they were muted, or an attempt to mute if they were unmuted
      */
-    public static RestAction<?> of(GuildVoiceGuildMuteEvent event)
+    public static AuditableRestAction<Void> of(GuildVoiceGuildMuteEvent event)
     {
-        return null;
+        Member member = event.getMember();
+        boolean action = event.isGuildMuted();
+
+        return member.mute(!action);
     }
 
     /**

--- a/commons/src/main/java/com/jagrosh/jdautilities/commons/utils/InverseAction.java
+++ b/commons/src/main/java/com/jagrosh/jdautilities/commons/utils/InverseAction.java
@@ -86,10 +86,157 @@ import java.util.List;
  */
 public final class InverseAction
 {
-    /**
-     * @return An attempt to change the category's position back
-     */
-    public static ChannelManager of(CategoryUpdatePositionEvent event)
+    public static RestAction<?> of(GenericEvent event)
+    {
+        if (event instanceof CategoryUpdatePositionEvent)
+            return inverse((CategoryUpdatePositionEvent) event);
+
+        else if (event instanceof CategoryUpdateNameEvent)
+            return inverse((CategoryUpdateNameEvent) event);
+
+        else if (event instanceof CategoryCreateEvent)
+            return inverse((CategoryCreateEvent) event);
+
+        else if (event instanceof GuildInviteCreateEvent)
+            return inverse((GuildInviteCreateEvent) event);
+
+        else if (event instanceof GuildJoinEvent)
+            return inverse((GuildJoinEvent) event);
+
+        else if (event instanceof GuildBanEvent)
+            return inverse((GuildBanEvent) event);
+
+        else if (event instanceof GuildUnbanEvent)
+            return inverse((GuildUnbanEvent) event);
+
+        else if (event instanceof GuildMemberRoleAddEvent)
+            return inverse((GuildMemberRoleAddEvent) event);
+
+        else if (event instanceof GuildMemberRoleRemoveEvent)
+            return inverse((GuildMemberRoleRemoveEvent) event);
+
+        else if (event instanceof GuildMemberUpdateNicknameEvent)
+            return inverse((GuildMemberUpdateNicknameEvent) event);
+
+        else if (event instanceof GuildMemberJoinEvent)
+            return inverse((GuildMemberJoinEvent) event);
+
+        else if (event instanceof GuildVoiceGuildDeafenEvent)
+            return inverse((GuildVoiceGuildDeafenEvent) event);
+
+        else if (event instanceof GuildVoiceJoinEvent)
+            return inverse((GuildVoiceJoinEvent) event);
+
+        else if (event instanceof GuildVoiceMoveEvent)
+            return inverse((GuildVoiceMoveEvent) event);
+
+        else if (event instanceof GuildVoiceGuildMuteEvent)
+            return inverse((GuildVoiceGuildMuteEvent) event);
+
+        else if (event instanceof PermissionOverrideCreateEvent)
+            return inverse((PermissionOverrideCreateEvent) event);
+
+        else if (event instanceof PermissionOverrideDeleteEvent)
+            return inverse((PermissionOverrideDeleteEvent) event);
+
+        else if (event instanceof PermissionOverrideUpdateEvent)
+            return inverse((PermissionOverrideUpdateEvent) event);
+
+        else if (event instanceof EmoteAddedEvent)
+            return inverse((EmoteAddedEvent) event);
+
+        else if (event instanceof EmoteUpdateNameEvent)
+            return inverse((EmoteUpdateNameEvent) event);
+
+        else if (event instanceof EmoteUpdateRolesEvent)
+            return inverse((EmoteUpdateRolesEvent) event);
+
+        else if (event instanceof RoleCreateEvent)
+            return inverse((RoleCreateEvent) event);
+
+        else if (event instanceof RoleDeleteEvent)
+            return inverse((RoleDeleteEvent) event);
+
+        else if (event instanceof RoleUpdateMentionableEvent)
+            return inverse((RoleUpdateMentionableEvent) event);
+
+        else if (event instanceof RoleUpdatePositionEvent)
+            return inverse((RoleUpdatePositionEvent) event);
+
+        else if (event instanceof RoleUpdatePermissionsEvent)
+            return inverse((RoleUpdatePermissionsEvent) event);
+
+        else if (event instanceof RoleUpdateNameEvent)
+            return inverse((RoleUpdateNameEvent) event);
+
+        else if (event instanceof RoleUpdateColorEvent)
+            return inverse((RoleUpdateColorEvent) event);
+
+        else if (event instanceof PrivateChannelCreateEvent)
+            return inverse((PrivateChannelCreateEvent) event);
+
+        else if (event instanceof VoiceChannelDeleteEvent)
+            return inverse((VoiceChannelDeleteEvent) event);
+
+        else if (event instanceof VoiceChannelCreateEvent)
+            return inverse((VoiceChannelCreateEvent) event);
+
+        else if (event instanceof VoiceChannelUpdateNameEvent)
+            return inverse((VoiceChannelUpdateNameEvent) event);
+
+        else if (event instanceof VoiceChannelUpdateParentEvent)
+            return inverse((VoiceChannelUpdateParentEvent) event);
+
+        else if (event instanceof VoiceChannelUpdatePositionEvent)
+            return inverse((VoiceChannelUpdatePositionEvent) event);
+
+        else if (event instanceof VoiceChannelUpdateBitrateEvent)
+            return inverse((VoiceChannelUpdateBitrateEvent) event);
+
+        else if (event instanceof VoiceChannelUpdateUserLimitEvent)
+            return inverse((VoiceChannelUpdateUserLimitEvent) event);
+
+        else if (event instanceof TextChannelCreateEvent)
+            return inverse((TextChannelCreateEvent) event);
+
+        else if (event instanceof TextChannelUpdateTopicEvent)
+            return inverse((TextChannelUpdateTopicEvent) event);
+
+        else if (event instanceof TextChannelUpdateNameEvent)
+            return inverse((TextChannelUpdateNameEvent) event);
+
+        else if (event instanceof TextChannelUpdateSlowmodeEvent)
+            return inverse((TextChannelUpdateSlowmodeEvent) event);
+
+        else if (event instanceof TextChannelUpdatePositionEvent)
+            return inverse((TextChannelUpdatePositionEvent) event);
+
+        else if (event instanceof TextChannelUpdateNSFWEvent)
+            return inverse((TextChannelUpdateNSFWEvent) event);
+
+        else if (event instanceof TextChannelUpdateParentEvent)
+            return inverse((TextChannelUpdateParentEvent) event);
+
+        else if (event instanceof MessageReactionAddEvent)
+            return inverse((MessageReactionAddEvent) event);
+
+        else if (event instanceof MessageReceivedEvent)
+            return inverse((MessageReceivedEvent) event);
+
+        else if (event instanceof StoreChannelUpdatePositionEvent)
+            return inverse((StoreChannelUpdatePositionEvent) event);
+
+        else if (event instanceof StoreChannelUpdateNameEvent)
+            return inverse((StoreChannelUpdateNameEvent) event);
+
+        else if (event instanceof StoreChannelCreateEvent)
+            return inverse((StoreChannelCreateEvent) event);
+
+        else
+            throw new InversionException("No possible inversion for event: " + event);
+    }
+
+    private static ChannelManager inverse(CategoryUpdatePositionEvent event)
     {
         ChannelManager manager = event.getCategory().getManager();
         int oldPosition = event.getOldPosition();
@@ -97,10 +244,7 @@ public final class InverseAction
         return manager.setPosition(oldPosition);
     }
 
-    /**
-     * @return An attempt to change the category's name back
-     */
-    public static ChannelManager of(CategoryUpdateNameEvent event)
+    private static ChannelManager inverse(CategoryUpdateNameEvent event)
     {
         ChannelManager manager = event.getCategory().getManager();
         String oldName = event.getOldName();
@@ -108,34 +252,22 @@ public final class InverseAction
         return manager.setName(oldName);
     }
 
-    /**
-     * @return An attempt to remove said category
-     */
-    public static AuditableRestAction<Void> of(CategoryCreateEvent event)
+    private static AuditableRestAction<Void> inverse(CategoryCreateEvent event)
     {
         return event.getCategory().delete();
     }
 
-    /**
-     * @return An attempt to remove said invite
-     */
-    public static AuditableRestAction<Void> of(GuildInviteCreateEvent event)
+    private static AuditableRestAction<Void> inverse(GuildInviteCreateEvent event)
     {
         return event.getInvite().delete();
     }
 
-    /**
-     * @return An attempt to leave said guild
-     */
-    public static RestAction<Void> of(GuildJoinEvent event)
+    private static RestAction<Void> inverse(GuildJoinEvent event)
     {
         return event.getGuild().leave();
     }
 
-    /**
-     * @return An attempt to unban them
-     */
-    public static RestAction<Void> of(GuildBanEvent event)
+    private static RestAction<Void> inverse(GuildBanEvent event)
     {
         Guild guild = event.getGuild();
         User user = event.getUser();
@@ -143,10 +275,7 @@ public final class InverseAction
         return guild.unban(user);
     }
 
-    /**
-     * @return An attempt to ban them again (0 message deletion days will be assumed)
-     */
-    public static AuditableRestAction<Void> of(GuildUnbanEvent event)
+    private static AuditableRestAction<Void> inverse(GuildUnbanEvent event)
     {
         Guild guild = event.getGuild();
         User user = event.getUser();
@@ -154,10 +283,7 @@ public final class InverseAction
         return guild.ban(user, 0);
     }
 
-    /**
-     * @return An attempt to take said roles away
-     */
-    public static AuditableRestAction<Void> of(GuildMemberRoleAddEvent event)
+    private static AuditableRestAction<Void> inverse(GuildMemberRoleAddEvent event)
     {
         Guild guild = event.getGuild();
         Member member = event.getMember();
@@ -166,10 +292,7 @@ public final class InverseAction
         return guild.modifyMemberRoles(member, null, addedRoles);
     }
 
-    /**
-     * @return An attempt to give the member the roles back
-     */
-    public static AuditableRestAction<Void> of(GuildMemberRoleRemoveEvent event)
+    private static AuditableRestAction<Void> inverse(GuildMemberRoleRemoveEvent event)
     {
         Guild guild = event.getGuild();
         Member member = event.getMember();
@@ -178,10 +301,7 @@ public final class InverseAction
         return guild.modifyMemberRoles(member, rolesRemoved, null);
     }
 
-    /**
-     * @return An attempt to change the member's nickname back
-     */
-    public static AuditableRestAction<Void> of(GuildMemberUpdateNicknameEvent event)
+    private static AuditableRestAction<Void> inverse(GuildMemberUpdateNicknameEvent event)
     {
         Member member = event.getMember();
         String oldNick = event.getOldNickname();
@@ -191,26 +311,17 @@ public final class InverseAction
 
     //TODO Look into all the GenericGuildUpdateEvents. There are a lot
 
-    /**
-     * @return An attempt to kick said member
-     */
-    public static AuditableRestAction<Void> of(GuildMemberJoinEvent event)
+    private static AuditableRestAction<Void> inverse(GuildMemberJoinEvent event)
     {
         return event.getMember().kick();
     }
 
-    /**
-     * @return An attempt to undeafen if they were deafened, or an attempt to deafen if they were undeafened
-     */
-    public static RestAction<Void> of(GuildVoiceGuildDeafenEvent event)
+    private static RestAction<Void> inverse(GuildVoiceGuildDeafenEvent event)
     {
         return event.getGuild().leave();
     }
 
-    /**
-     * @return An attempt to kick them from the channel
-     */
-    public static RestAction<Void> of(GuildVoiceJoinEvent event)
+    private static RestAction<Void> inverse(GuildVoiceJoinEvent event)
     {
         Guild guild = event.getGuild();
         Member member = event.getMember();
@@ -218,10 +329,7 @@ public final class InverseAction
         return guild.kickVoiceMember(member);
     }
 
-    /**
-     * @return An attempt to move them back to where they just were
-     */
-    public static RestAction<Void> of(GuildVoiceMoveEvent event)
+    private static RestAction<Void> inverse(GuildVoiceMoveEvent event)
     {
         Guild guild = event.getGuild();
         Member member = event.getMember();
@@ -230,10 +338,7 @@ public final class InverseAction
         return guild.moveVoiceMember(member, previous);
     }
 
-    /**
-     * @return An attempt to unmute if they were muted, or an attempt to mute if they were unmuted
-     */
-    public static AuditableRestAction<Void> of(GuildVoiceGuildMuteEvent event)
+    private static AuditableRestAction<Void> inverse(GuildVoiceGuildMuteEvent event)
     {
         Member member = event.getMember();
         boolean action = event.isGuildMuted();
@@ -241,19 +346,12 @@ public final class InverseAction
         return member.mute(!action);
     }
 
-    /**
-     * @return An attempt to remove said override
-     */
-    public static AuditableRestAction<Void> of(PermissionOverrideCreateEvent event)
+    private static AuditableRestAction<Void> inverse(PermissionOverrideCreateEvent event)
     {
         return event.getPermissionOverride().delete();
     }
 
-    /**
-     * @return An attempt to add the override back
-     * @throws com.jagrosh.jdautilities.commons.utils.InverseAction.InversionException If the override's permission holder isn't cached
-     */
-    public static PermissionOverrideAction of(PermissionOverrideDeleteEvent event)
+    private static PermissionOverrideAction inverse(PermissionOverrideDeleteEvent event)
     {
         PermissionOverride deleted = event.getPermissionOverride();
         IPermissionHolder holder = event.getPermissionHolder();
@@ -268,10 +366,7 @@ public final class InverseAction
                     .setPermissions(allowed, denied);
     }
 
-    /**
-     * @return An attempt to set rules to what they just were
-     */
-    public static PermissionOverrideAction of(PermissionOverrideUpdateEvent event)
+    private static PermissionOverrideAction inverse(PermissionOverrideUpdateEvent event)
     {
         PermissionOverride updated = event.getPermissionOverride();
         EnumSet<Permission> allow = event.getOldAllow();
@@ -281,18 +376,12 @@ public final class InverseAction
                       .setAllow(allow).setDeny(deny);
     }
 
-    /**
-     * @return An attempt to remove said emote
-     */
-    public static AuditableRestAction<Void> of(EmoteAddedEvent event)
+    private static AuditableRestAction<Void> inverse(EmoteAddedEvent event)
     {
         return event.getEmote().delete();
     }
 
-    /**
-     * @return An attempt to change the name back to what it just was
-     */
-    public static EmoteManager of(EmoteUpdateNameEvent event)
+    private static EmoteManager inverse(EmoteUpdateNameEvent event)
     {
         Emote emote = event.getEmote();
         EmoteManager manager = emote.getManager();
@@ -301,10 +390,7 @@ public final class InverseAction
         return manager.setName(oldName);
     }
 
-    /**
-     * @return An attempt to change the roles to what they just were
-     */
-    public static EmoteManager of(EmoteUpdateRolesEvent event)
+    private static EmoteManager inverse(EmoteUpdateRolesEvent event)
     {
         Emote emote = event.getEmote();
         EmoteManager manager = emote.getManager();
@@ -313,26 +399,17 @@ public final class InverseAction
         return manager.setRoles(oldRoles);
     }
 
-    /**
-     * @return An attempt to remove said role
-     */
-    public static AuditableRestAction<Void> of(RoleCreateEvent event)
+    private static AuditableRestAction<Void> inverse(RoleCreateEvent event)
     {
         return event.getRole().delete();
     }
 
-    /**
-     * @return An attempt to add the role back
-     */
-    public static RoleAction of(RoleDeleteEvent event)
+    private static RoleAction inverse(RoleDeleteEvent event)
     {
         return event.getRole().createCopy();
     }
 
-    /**
-     * @return An attempt to change the mentionable state back
-     */
-    public static RoleManager of(RoleUpdateMentionableEvent event)
+    private static RoleManager inverse(RoleUpdateMentionableEvent event)
     {
         Role role = event.getRole();
         RoleManager manager = role.getManager();
@@ -341,10 +418,7 @@ public final class InverseAction
         return manager.setMentionable(oldState);
     }
 
-    /**
-     * @return An attempt to move the role back to where it just was
-     */
-    public static OrderAction<Role, RoleOrderAction> of(RoleUpdatePositionEvent event)
+    private static OrderAction<Role, RoleOrderAction> inverse(RoleUpdatePositionEvent event)
     {
         Role role = event.getRole();
         int oldPos = event.getOldPosition();
@@ -355,10 +429,7 @@ public final class InverseAction
                     .moveTo(oldPos);
     }
 
-    /**
-     * @return An attempt to change the role's permissions back
-     */
-    public static RoleManager of(RoleUpdatePermissionsEvent event)
+    private static RoleManager inverse(RoleUpdatePermissionsEvent event)
     {
         Role role = event.getRole();
         RoleManager manager = role.getManager();
@@ -367,10 +438,7 @@ public final class InverseAction
         return manager.setPermissions(oldPerms);
     }
 
-    /**
-     * @return An attempt to change the role's name back
-     */
-    public static RoleManager of(RoleUpdateNameEvent event)
+    private static RoleManager inverse(RoleUpdateNameEvent event)
     {
         Role role = event.getRole();
         RoleManager manager = role.getManager();
@@ -381,10 +449,7 @@ public final class InverseAction
 
     //TODO What the hell is a hoisted role? Lmao, look at that later
 
-    /**
-     * @return An attempt to change the role's color back to what it just was
-     */
-    public static RoleManager of(RoleUpdateColorEvent event)
+    private static RoleManager inverse(RoleUpdateColorEvent event)
     {
         Role role = event.getRole();
         RoleManager manager = role.getManager();
@@ -393,18 +458,12 @@ public final class InverseAction
         return manager.setColor(oldColor);
     }
 
-    /**
-     * @return An attempt to close said channel
-     */
-    public static RestAction<Void> of(PrivateChannelCreateEvent event)
+    private static RestAction<Void> inverse(PrivateChannelCreateEvent event)
     {
         return event.getChannel().close();
     }
 
-    /**
-     * @return An attempt to make the channel again
-     */
-    public static ChannelAction<VoiceChannel> of(VoiceChannelDeleteEvent event)
+    private static ChannelAction<VoiceChannel> inverse(VoiceChannelDeleteEvent event)
     {
         Guild guild = event.getGuild();
         VoiceChannel deleted = event.getChannel();
@@ -416,18 +475,12 @@ public final class InverseAction
                     .setParent(deleted.getParent());
     }
 
-    /**
-     * @return An attempt to remove said channel
-     */
-    public static AuditableRestAction<Void> of(VoiceChannelCreateEvent event)
+    private static AuditableRestAction<Void> inverse(VoiceChannelCreateEvent event)
     {
         return event.getChannel().delete();
     }
 
-    /**
-     * @return An attempt to change the voice channel's name back
-     */
-    public static ChannelManager of(VoiceChannelUpdateNameEvent event)
+    private static ChannelManager inverse(VoiceChannelUpdateNameEvent event)
     {
         VoiceChannel updated = event.getChannel();
         ChannelManager manager = updated.getManager();
@@ -436,10 +489,7 @@ public final class InverseAction
         return manager.setName(oldName);
     }
 
-    /**
-     * @return An attempt to change the voice channel's parent back
-     */
-    public static ChannelManager of(VoiceChannelUpdateParentEvent event)
+    private static ChannelManager inverse(VoiceChannelUpdateParentEvent event)
     {
         VoiceChannel updated = event.getChannel();
         ChannelManager manager = updated.getManager();
@@ -448,10 +498,7 @@ public final class InverseAction
         return manager.setParent(oldParent);
     }
 
-    /**
-     * @return An attempt to change the voice channel's position back
-     */
-    public static ChannelManager of(VoiceChannelUpdatePositionEvent event)
+    private static ChannelManager inverse(VoiceChannelUpdatePositionEvent event)
     {
         VoiceChannel updated = event.getChannel();
         ChannelManager manager = updated.getManager();
@@ -460,10 +507,7 @@ public final class InverseAction
         return manager.setPosition(oldPos);
     }
 
-    /**
-     * @return An attempt to change the voice channel's bitrate back
-     */
-    public static ChannelManager of(VoiceChannelUpdateBitrateEvent event)
+    private static ChannelManager inverse(VoiceChannelUpdateBitrateEvent event)
     {
         VoiceChannel updated = event.getChannel();
         ChannelManager manager = updated.getManager();
@@ -472,10 +516,7 @@ public final class InverseAction
         return manager.setBitrate(oldBitrate);
     }
 
-    /**
-     * @return An attempt to change the voice channel's user limit back
-     */
-    public static ChannelManager of(VoiceChannelUpdateUserLimitEvent event)
+    private static ChannelManager inverse(VoiceChannelUpdateUserLimitEvent event)
     {
         VoiceChannel updated = event.getChannel();
         ChannelManager manager = updated.getManager();
@@ -484,18 +525,12 @@ public final class InverseAction
         return manager.setUserLimit(oldLimit);
     }
 
-    /**
-     * @return An attempt to remove said channel
-     */
-    public static AuditableRestAction<Void> of(TextChannelCreateEvent event)
+    private static AuditableRestAction<Void> inverse(TextChannelCreateEvent event)
     {
         return event.getChannel().delete();
     }
 
-    /**
-     * @return An attempt to change the text channel's topic back
-     */
-    public static ChannelManager of(TextChannelUpdateTopicEvent event)
+    private static ChannelManager inverse(TextChannelUpdateTopicEvent event)
     {
         TextChannel updated = event.getChannel();
         ChannelManager manager = updated.getManager();
@@ -504,10 +539,7 @@ public final class InverseAction
         return manager.setTopic(oldTopic);
     }
 
-    /**
-     * @return An attempt to change the text channel's name back
-     */
-    public static ChannelManager of(TextChannelUpdateNameEvent event)
+    private static ChannelManager inverse(TextChannelUpdateNameEvent event)
     {
         TextChannel updated = event.getChannel();
         ChannelManager manager = updated.getManager();
@@ -516,10 +548,7 @@ public final class InverseAction
         return manager.setName(oldName);
     }
 
-    /**
-     * @return An attempt to change the text channel's slowmode value back
-     */
-    public static ChannelManager of(TextChannelUpdateSlowmodeEvent event)
+    private static ChannelManager inverse(TextChannelUpdateSlowmodeEvent event)
     {
         TextChannel updated = event.getChannel();
         ChannelManager manager = updated.getManager();
@@ -528,10 +557,7 @@ public final class InverseAction
         return manager.setSlowmode(oldState);
     }
 
-    /**
-     * @return An attempt to move the text channel back
-     */
-    public static ChannelManager of(TextChannelUpdatePositionEvent event)
+    private static ChannelManager inverse(TextChannelUpdatePositionEvent event)
     {
         TextChannel updated = event.getChannel();
         ChannelManager manager = updated.getManager();
@@ -540,10 +566,7 @@ public final class InverseAction
         return manager.setPosition(oldPos);
     }
 
-    /**
-     * @return An attempt to change the text channel's NSFW state back
-     */
-    public static ChannelManager of(TextChannelUpdateNSFWEvent event)
+    private static ChannelManager inverse(TextChannelUpdateNSFWEvent event)
     {
         TextChannel updated = event.getChannel();
         ChannelManager manager = updated.getManager();
@@ -552,10 +575,7 @@ public final class InverseAction
         return manager.setNSFW(oldState);
     }
 
-    /**
-     * @return An attempt to change the text channel's parent back
-     */
-    public static ChannelManager of(TextChannelUpdateParentEvent event)
+    private static ChannelManager inverse(TextChannelUpdateParentEvent event)
     {
         TextChannel updated = event.getChannel();
         ChannelManager manager = updated.getManager();
@@ -564,10 +584,7 @@ public final class InverseAction
         return manager.setParent(oldParent);
     }
 
-    /**
-     * @return An attempt to remove said reaction
-     */
-    public static RestAction<Void> of(MessageReactionAddEvent event)
+    private static RestAction<Void> inverse(MessageReactionAddEvent event)
     {
         MessageReaction reaction = event.getReaction();
         User user = event.getUser();
@@ -578,18 +595,12 @@ public final class InverseAction
         return reaction.removeReaction(user);
     }
 
-    /**
-     * @return An attempt to remove said message
-     */
-    public static AuditableRestAction<Void> of(MessageReceivedEvent event)
+    private static AuditableRestAction<Void> inverse(MessageReceivedEvent event)
     {
         return event.getMessage().delete();
     }
 
-    /**
-     * @return An attempt to move the store channel back
-     */
-    public static ChannelManager of(StoreChannelUpdatePositionEvent event)
+    private static ChannelManager inverse(StoreChannelUpdatePositionEvent event)
     {
         StoreChannel updated = event.getChannel();
         ChannelManager manager = updated.getManager();
@@ -598,10 +609,7 @@ public final class InverseAction
         return manager.setPosition(oldPos);
     }
 
-    /**
-     * @return An attempt to change the store channel's name back
-     */
-    public static ChannelManager of(StoreChannelUpdateNameEvent event)
+    private static ChannelManager inverse(StoreChannelUpdateNameEvent event)
     {
         StoreChannel update = event.getChannel();
         ChannelManager manager = update.getManager();
@@ -610,10 +618,7 @@ public final class InverseAction
         return manager.setName(oldName);
     }
 
-    /**
-     * @return An attempt to remove said store channel
-     */
-    public static AuditableRestAction<Void> of(StoreChannelCreateEvent event)
+    private static AuditableRestAction<Void> inverse(StoreChannelCreateEvent event)
     {
         return event.getChannel().delete();
     }

--- a/commons/src/main/java/com/jagrosh/jdautilities/commons/utils/InverseAction.java
+++ b/commons/src/main/java/com/jagrosh/jdautilities/commons/utils/InverseAction.java
@@ -18,7 +18,6 @@ import net.dv8tion.jda.api.events.emote.EmoteAddedEvent;
 import net.dv8tion.jda.api.events.emote.update.EmoteUpdateNameEvent;
 import net.dv8tion.jda.api.events.emote.update.EmoteUpdateRolesEvent;
 import net.dv8tion.jda.api.events.guild.GuildJoinEvent;
-import net.dv8tion.jda.api.events.guild.GuildUnbanEvent;
 import net.dv8tion.jda.api.events.guild.invite.GuildInviteCreateEvent;
 import net.dv8tion.jda.api.events.guild.member.GuildMemberJoinEvent;
 import net.dv8tion.jda.api.events.guild.member.GuildMemberRoleAddEvent;
@@ -36,7 +35,6 @@ import net.dv8tion.jda.api.events.message.react.MessageReactionAddEvent;
 import net.dv8tion.jda.api.events.role.RoleCreateEvent;
 import net.dv8tion.jda.api.events.role.RoleDeleteEvent;
 import net.dv8tion.jda.api.events.role.update.*;
-import net.dv8tion.jda.api.events.self.*;
 import net.dv8tion.jda.api.managers.ChannelManager;
 import net.dv8tion.jda.api.managers.EmoteManager;
 import net.dv8tion.jda.api.managers.RoleManager;
@@ -52,7 +50,6 @@ import java.awt.*;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * A utility class meant to serve as a way to rollback certain events where it makes sense to.
@@ -63,7 +60,7 @@ import java.util.stream.Collectors;
  * In events where something is posted, the inverse would be another request to remove said post, for example.
  * <p>
  * Also, since it's a RestAction that simply makes an attempt at the inverse, it's not always possible due to multiple
- * factors, such as permissions, etc. For example, trying to inverse a {@link net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent GuildMessageReceievedEvent} in a channel with no permission
+ * factors, such as permissions, etc. For example, trying to invert a {@link net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent GuildMessageReceievedEvent} in a channel with no permission
  * to remove messages will fail
  * </p>
  * <br>

--- a/commons/src/main/java/com/jagrosh/jdautilities/commons/utils/InverseAction.java
+++ b/commons/src/main/java/com/jagrosh/jdautilities/commons/utils/InverseAction.java
@@ -145,14 +145,6 @@ public final class InverseAction
     }
 
     /**
-     * @return An attempt to ban said member again
-     */
-    public static RestAction<?> of(GuildUnbanEvent event)
-    {
-        return null;
-    }
-
-    /**
      * @return An attempt to undeafen if they were deafened, or an attempt to deafen if they were undeafened
      */
     public static RestAction<?> of(GuildVoiceGuildDeafenEvent event)

--- a/commons/src/main/java/com/jagrosh/jdautilities/commons/utils/InverseAction.java
+++ b/commons/src/main/java/com/jagrosh/jdautilities/commons/utils/InverseAction.java
@@ -456,57 +456,81 @@ public final class InverseAction
     /**
      * @return An attempt to remove said channel
      */
-    public static RestAction<?> of(TextChannelCreateEvent event)
+    public static AuditableRestAction<Void> of(TextChannelCreateEvent event)
     {
-        return null;
+        return event.getChannel().delete();
     }
 
     /**
      * @return An attempt to change the text channel's topic back
      */
-    public static RestAction<?> of(TextChannelUpdateTopicEvent event)
+    public static ChannelManager of(TextChannelUpdateTopicEvent event)
     {
-        return null;
+        TextChannel updated = event.getChannel();
+        ChannelManager manager = updated.getManager();
+        String oldTopic = event.getOldTopic();
+
+        return manager.setTopic(oldTopic);
     }
 
     /**
      * @return An attempt to change the text channel's name back
      */
-    public static RestAction<?> of(TextChannelUpdateNameEvent event)
+    public static ChannelManager of(TextChannelUpdateNameEvent event)
     {
-        return null;
+        TextChannel updated = event.getChannel();
+        ChannelManager manager = updated.getManager();
+        String oldName = event.getOldName();
+
+        return manager.setName(oldName);
     }
 
     /**
      * @return An attempt to change the text channel's slowmode value back
      */
-    public static RestAction<?> of(TextChannelUpdateSlowmodeEvent event)
+    public static ChannelManager of(TextChannelUpdateSlowmodeEvent event)
     {
-        return null;
+        TextChannel updated = event.getChannel();
+        ChannelManager manager = updated.getManager();
+        int oldState = event.getOldSlowmode();
+
+        return manager.setSlowmode(oldState);
     }
 
     /**
      * @return An attempt to move the text channel back
      */
-    public static RestAction<?> of(TextChannelUpdatePositionEvent event)
+    public static ChannelManager of(TextChannelUpdatePositionEvent event)
     {
-        return null;
+        TextChannel updated = event.getChannel();
+        ChannelManager manager = updated.getManager();
+        int oldPos = event.getOldPosition();
+
+        return manager.setPosition(oldPos);
     }
 
     /**
      * @return An attempt to change the text channel's NSFW state back
      */
-    public static RestAction<?> of(TextChannelUpdateNSFWEvent event)
+    public static ChannelManager of(TextChannelUpdateNSFWEvent event)
     {
-        return null;
+        TextChannel updated = event.getChannel();
+        ChannelManager manager = updated.getManager();
+        boolean oldState = event.getOldNSFW();
+
+        return manager.setNSFW(oldState);
     }
 
     /**
      * @return An attempt to change the text channel's parent back
      */
-    public static RestAction<?> of(TextChannelUpdateParentEvent event)
+    public static ChannelManager of(TextChannelUpdateParentEvent event)
     {
-        return null;
+        TextChannel updated = event.getChannel();
+        ChannelManager manager = updated.getManager();
+        Category oldParent = event.getOldParent();
+
+        return manager.setParent(oldParent);
     }
 
     /**

--- a/commons/src/main/java/com/jagrosh/jdautilities/commons/utils/InverseAction.java
+++ b/commons/src/main/java/com/jagrosh/jdautilities/commons/utils/InverseAction.java
@@ -38,12 +38,15 @@ import net.dv8tion.jda.api.events.role.RoleDeleteEvent;
 import net.dv8tion.jda.api.events.role.update.*;
 import net.dv8tion.jda.api.events.self.*;
 import net.dv8tion.jda.api.managers.ChannelManager;
+import net.dv8tion.jda.api.managers.EmoteManager;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.requests.restaction.AuditableRestAction;
 import net.dv8tion.jda.api.requests.restaction.PermissionOverrideAction;
 
 import java.util.EnumSet;
+import java.util.HashSet;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * A utility class meant to serve as a way to rollback certain events where it makes sense to.
@@ -241,25 +244,33 @@ public final class InverseAction
     /**
      * @return An attempt to remove said emote
      */
-    public static RestAction<?> of(EmoteAddedEvent event)
+    public static AuditableRestAction<Void> of(EmoteAddedEvent event)
     {
-        return null;
+        return event.getEmote().delete();
     }
 
     /**
      * @return An attempt to change the name back to what it just was
      */
-    public static RestAction<?> of(EmoteUpdateNameEvent event)
+    public static EmoteManager of(EmoteUpdateNameEvent event)
     {
-        return null;
+        Emote emote = event.getEmote();
+        EmoteManager manager = emote.getManager();
+        String oldName = event.getOldName();
+
+        return manager.setName(oldName);
     }
 
     /**
      * @return An attempt to change the roles to what they just were
      */
-    public static RestAction<?> of(EmoteUpdateRolesEvent event)
+    public static EmoteManager of(EmoteUpdateRolesEvent event)
     {
-        return null;
+        Emote emote = event.getEmote();
+        EmoteManager manager = emote.getManager();
+        HashSet<Role> oldRoles = new HashSet<>(event.getOldRoles());
+
+        return manager.setRoles(oldRoles);
     }
 
     /**

--- a/commons/src/main/java/com/jagrosh/jdautilities/commons/utils/InverseAction.java
+++ b/commons/src/main/java/com/jagrosh/jdautilities/commons/utils/InverseAction.java
@@ -62,7 +62,7 @@ import net.dv8tion.jda.api.requests.restaction.AuditableRestAction;
  *
  * @author HydroPage90
  */
-public final class InverseEvent
+public final class InverseAction
 {
     /**
      * @return An attempt to change the category's position back

--- a/commons/src/main/java/com/jagrosh/jdautilities/commons/utils/InverseAction.java
+++ b/commons/src/main/java/com/jagrosh/jdautilities/commons/utils/InverseAction.java
@@ -57,12 +57,14 @@ import java.util.List;
  * A utility class meant to serve as a way to rollback certain events where it makes sense to.
  *
  * <p>
- * All methods are overloaded static factory methods, always returning a {@link net.dv8tion.jda.api.requests.RestAction RestAction}
+ * All methods are overloaded static factory methods, always returning a {@link net.dv8tion.jda.api.requests.RestAction RestAction<?>}
  * meant to "undo" the given event. Note that this will only be possible for events in which it makes sense.
  * In events where something is posted, the inverse would be another request to remove said post, for example.
+ * </p>
+ * <br>
  * <p>
  * Also, since it's a RestAction that simply makes an attempt at the inverse, it's not always possible due to multiple
- * factors, such as permissions, etc. For example, trying to invert a {@link net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent GuildMessageReceievedEvent} in a channel with no permission
+ * factors, such as permissions, etc. For example, trying to invert a {@link net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent GuildMessageReceivedEvent} in a channel with no permission
  * to remove messages will fail
  * </p>
  * <br>
@@ -73,9 +75,11 @@ import java.util.List;
  * Events fired for the deletion of something are a different story. Some cases are logical, but many are not, like the
  * removal of a text channel. Cases where the complete undoing of the event cannot be guaranteed are not implemented
  * </p>
+ * <br>
  * <p>
  * Keep in mind that inverting the deletion of something requires for a new object to be created with the same values.
- * But doing this can't possibly copy information such as the ID of the deleted object
+ * But doing this can't possibly copy information such as the ID of the deleted object or undo effects like everyone losing
+ * a role that is deleted
  *
  * @author HydroPage90
  */

--- a/commons/src/main/java/com/jagrosh/jdautilities/commons/utils/InverseAction.java
+++ b/commons/src/main/java/com/jagrosh/jdautilities/commons/utils/InverseAction.java
@@ -17,6 +17,7 @@ import net.dv8tion.jda.api.events.channel.voice.update.*;
 import net.dv8tion.jda.api.events.emote.EmoteAddedEvent;
 import net.dv8tion.jda.api.events.emote.update.EmoteUpdateNameEvent;
 import net.dv8tion.jda.api.events.emote.update.EmoteUpdateRolesEvent;
+import net.dv8tion.jda.api.events.guild.GuildBanEvent;
 import net.dv8tion.jda.api.events.guild.GuildJoinEvent;
 import net.dv8tion.jda.api.events.guild.invite.GuildInviteCreateEvent;
 import net.dv8tion.jda.api.events.guild.member.GuildMemberJoinEvent;
@@ -120,9 +121,31 @@ public final class InverseAction
     /**
      * @return An attempt to leave said guild
      */
-    public static RestAction<?> of(GuildJoinEvent event)
+    public static RestAction<Void> of(GuildJoinEvent event)
     {
         return event.getGuild().leave();
+    }
+
+    /**
+     * @return An attempt to ban them again (0 message deletion days will be assumed)
+     */
+    public static AuditableRestAction<Void> of(GuildBanEvent event)
+    {
+        Guild guild = event.getGuild();
+        User user = event.getUser();
+
+        return guild.ban(user, 0);
+    }
+
+    /**
+     * @return An attempt to ban them again
+     */
+    public static AuditableRestAction<Void> of(GuildBanEvent event, int delDays)
+    {
+        Guild guild = event.getGuild();
+        User user = event.getUser();
+
+        return guild.ban(user, delDays);
     }
 
     /**

--- a/commons/src/main/java/com/jagrosh/jdautilities/commons/utils/InverseAction.java
+++ b/commons/src/main/java/com/jagrosh/jdautilities/commons/utils/InverseAction.java
@@ -205,6 +205,9 @@ public final class InverseAction
         else if (event instanceof RoleUpdateNameEvent)
             return inverse((RoleUpdateNameEvent) event);
 
+        else if (event instanceof RoleUpdateHoistedEvent)
+            return inverse((RoleUpdateHoistedEvent) event);
+
         else if (event instanceof RoleUpdateColorEvent)
             return inverse((RoleUpdateColorEvent) event);
 
@@ -580,7 +583,14 @@ public final class InverseAction
         return manager.setName(oldName);
     }
 
-    //TODO What the hell is a hoisted role? Lmao, look at that later
+    private static RoleManager inverse(RoleUpdateHoistedEvent event)
+    {
+        Role role = event.getRole();
+        RoleManager manager = role.getManager();
+        Boolean oldState = event.getOldValue();
+
+        return manager.setHoisted(oldState);
+    }
 
     private static RoleManager inverse(RoleUpdateColorEvent event)
     {

--- a/commons/src/main/java/com/jagrosh/jdautilities/commons/utils/InverseAction.java
+++ b/commons/src/main/java/com/jagrosh/jdautilities/commons/utils/InverseAction.java
@@ -154,17 +154,6 @@ public final class InverseAction
     }
 
     /**
-     * @return An attempt to ban them again
-     */
-    public static AuditableRestAction<Void> of(GuildUnbanEvent event, int delDays)
-    {
-        Guild guild = event.getGuild();
-        User user = event.getUser();
-
-        return guild.ban(user, delDays);
-    }
-
-    /**
      * @return An attempt to take said roles away
      */
     public static AuditableRestAction<Void> of(GuildMemberRoleAddEvent event)

--- a/commons/src/main/java/com/jagrosh/jdautilities/commons/utils/InverseAction.java
+++ b/commons/src/main/java/com/jagrosh/jdautilities/commons/utils/InverseAction.java
@@ -42,6 +42,7 @@ import net.dv8tion.jda.api.managers.EmoteManager;
 import net.dv8tion.jda.api.managers.RoleManager;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.requests.restaction.AuditableRestAction;
+import net.dv8tion.jda.api.requests.restaction.ChannelAction;
 import net.dv8tion.jda.api.requests.restaction.PermissionOverrideAction;
 import net.dv8tion.jda.api.requests.restaction.RoleAction;
 import net.dv8tion.jda.api.requests.restaction.order.OrderAction;
@@ -372,57 +373,84 @@ public final class InverseAction
     /**
      * @return An attempt to make the channel again
      */
-    public static RestAction<?> of(VoiceChannelDeleteEvent event)
+    public static ChannelAction<VoiceChannel> of(VoiceChannelDeleteEvent event)
     {
-        return null;
+        Guild guild = event.getGuild();
+        VoiceChannel deleted = event.getChannel();
+
+        return guild.createVoiceChannel(deleted.getName())
+                    .setUserlimit(deleted.getUserLimit())
+                    .setBitrate(deleted.getBitrate())
+                    .setPosition(deleted.getPosition())
+                    .setParent(deleted.getParent());
     }
 
     /**
      * @return An attempt to remove said channel
      */
-    public static RestAction<?> of(VoiceChannelCreateEvent event)
+    public static AuditableRestAction<Void> of(VoiceChannelCreateEvent event)
     {
-        return null;
+        return event.getChannel().delete();
     }
 
     /**
      * @return An attempt to change the voice channel's name back
      */
-    public static RestAction<?> of(VoiceChannelUpdateNameEvent event)
+    public static ChannelManager of(VoiceChannelUpdateNameEvent event)
     {
-        return null;
+        VoiceChannel updated = event.getChannel();
+        ChannelManager manager = updated.getManager();
+        String oldName = event.getOldName();
+
+        return manager.setName(oldName);
     }
 
     /**
      * @return An attempt to change the voice channel's parent back
      */
-    public static RestAction<?> of(VoiceChannelUpdateParentEvent event)
+    public static ChannelManager of(VoiceChannelUpdateParentEvent event)
     {
-        return null;
+        VoiceChannel updated = event.getChannel();
+        ChannelManager manager = updated.getManager();
+        Category oldParent = event.getOldParent();
+
+        return manager.setParent(oldParent);
     }
 
     /**
      * @return An attempt to change the voice channel's position back
      */
-    public static RestAction<?> of(VoiceChannelUpdatePositionEvent event)
+    public static ChannelManager of(VoiceChannelUpdatePositionEvent event)
     {
-        return null;
+        VoiceChannel updated = event.getChannel();
+        ChannelManager manager = updated.getManager();
+        int oldPos = event.getOldPosition();
+
+        return manager.setPosition(oldPos);
     }
 
     /**
      * @return An attempt to change the voice channel's bitrate back
      */
-    public static RestAction<?> of(VoiceChannelUpdateBitrateEvent event)
+    public static ChannelManager of(VoiceChannelUpdateBitrateEvent event)
     {
-        return null;
+        VoiceChannel updated = event.getChannel();
+        ChannelManager manager = updated.getManager();
+        int oldBitrate = event.getOldBitrate();
+
+        return manager.setBitrate(oldBitrate);
     }
 
     /**
      * @return An attempt to change the voice channel's user limit back
      */
-    public static RestAction<?> of(VoiceChannelUpdateUserLimitEvent event)
+    public static ChannelManager of(VoiceChannelUpdateUserLimitEvent event)
     {
-        return null;
+        VoiceChannel updated = event.getChannel();
+        ChannelManager manager = updated.getManager();
+        int oldLimit = event.getOldUserLimit();
+
+        return manager.setUserLimit(oldLimit);
     }
 
     /**

--- a/commons/src/main/java/com/jagrosh/jdautilities/commons/utils/InverseAction.java
+++ b/commons/src/main/java/com/jagrosh/jdautilities/commons/utils/InverseAction.java
@@ -575,7 +575,13 @@ public final class InverseAction
      */
     public static RestAction<Void> of(MessageReactionAddEvent event)
     {
-        return event.getReaction().removeReaction();
+        MessageReaction reaction = event.getReaction();
+        User user = event.getUser();
+
+        if (user == null)
+            throw new InversionException("No cached user to remove reaction from");
+
+        return reaction.removeReaction(user);
     }
 
     /**

--- a/commons/src/main/java/com/jagrosh/jdautilities/commons/utils/InverseAction.java
+++ b/commons/src/main/java/com/jagrosh/jdautilities/commons/utils/InverseAction.java
@@ -111,19 +111,27 @@ public final class InverseAction
     }
 
     /**
-     * @return An attempt to take said role away
+     * @return An attempt to take said roles away
      */
     public static RestAction<?> of(GuildMemberRoleAddEvent event)
     {
-        return null;
+        Guild guild = event.getGuild();
+        Member member = event.getMember();
+        List<Role> addedRoles = event.getRoles();
+
+        return guild.modifyMemberRoles(member, null, addedRoles);
     }
 
     /**
-     * @return An attempt to give the member the role back
+     * @return An attempt to give the member the roles back
      */
     public static RestAction<?> of(GuildMemberRoleRemoveEvent event)
     {
-        return null;
+        Guild guild = event.getGuild();
+        Member member = event.getMember();
+        List<Role> rolesRemoved = event.getRoles();
+
+        return guild.modifyMemberRoles(member, rolesRemoved, null);
     }
 
     /**
@@ -131,7 +139,10 @@ public final class InverseAction
      */
     public static RestAction<?> of(GuildMemberUpdateNicknameEvent event)
     {
-        return null;
+        Member member = event.getMember();
+        String oldNick = event.getOldNickname();
+
+        return member.modifyNickname(oldNick);
     }
 
     //TODO Look into all the GenericGuildUpdateEvents. There are a lot
@@ -141,7 +152,7 @@ public final class InverseAction
      */
     public static RestAction<?> of(GuildMemberJoinEvent event)
     {
-        return null;
+        return event.getMember().kick();
     }
 
     /**

--- a/commons/src/main/java/com/jagrosh/jdautilities/commons/utils/InverseAction.java
+++ b/commons/src/main/java/com/jagrosh/jdautilities/commons/utils/InverseAction.java
@@ -549,29 +549,35 @@ public final class InverseAction
         return event.getMessage().delete();
     }
 
-    // I'm not really sure what to do about store channels.
-
     /**
      * @return An attempt to move the store channel back
      */
-    public static RestAction<?> of(StoreChannelUpdatePositionEvent event)
+    public static ChannelManager of(StoreChannelUpdatePositionEvent event)
     {
-        return null;
+        StoreChannel updated = event.getChannel();
+        ChannelManager manager = updated.getManager();
+        int oldPos = event.getOldPosition();
+
+        return manager.setPosition(oldPos);
     }
 
     /**
      * @return An attempt to change the store channel's name back
      */
-    public static RestAction<?> of(StoreChannelUpdateNameEvent event)
+    public static ChannelManager of(StoreChannelUpdateNameEvent event)
     {
-        return null;
+        StoreChannel update = event.getChannel();
+        ChannelManager manager = update.getManager();
+        String oldName = event.getOldName();
+
+        return manager.setName(oldName);
     }
 
     /**
      * @return An attempt to remove said store channel
      */
-    public static RestAction<?> of(StoreChannelCreateEvent event)
+    public static AuditableRestAction<Void> of(StoreChannelCreateEvent event)
     {
-        return null;
+        return event.getChannel().delete();
     }
 }

--- a/commons/src/main/java/com/jagrosh/jdautilities/commons/utils/InverseAction.java
+++ b/commons/src/main/java/com/jagrosh/jdautilities/commons/utils/InverseAction.java
@@ -1,6 +1,7 @@
 package com.jagrosh.jdautilities.commons.utils;
 
 import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.Region;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.events.GenericEvent;
 import net.dv8tion.jda.api.events.channel.category.CategoryCreateEvent;
@@ -29,6 +30,7 @@ import net.dv8tion.jda.api.events.guild.member.update.GuildMemberUpdateNicknameE
 import net.dv8tion.jda.api.events.guild.override.PermissionOverrideCreateEvent;
 import net.dv8tion.jda.api.events.guild.override.PermissionOverrideDeleteEvent;
 import net.dv8tion.jda.api.events.guild.override.PermissionOverrideUpdateEvent;
+import net.dv8tion.jda.api.events.guild.update.*;
 import net.dv8tion.jda.api.events.guild.voice.GuildVoiceGuildDeafenEvent;
 import net.dv8tion.jda.api.events.guild.voice.GuildVoiceGuildMuteEvent;
 import net.dv8tion.jda.api.events.guild.voice.GuildVoiceJoinEvent;
@@ -40,6 +42,7 @@ import net.dv8tion.jda.api.events.role.RoleDeleteEvent;
 import net.dv8tion.jda.api.events.role.update.*;
 import net.dv8tion.jda.api.managers.ChannelManager;
 import net.dv8tion.jda.api.managers.EmoteManager;
+import net.dv8tion.jda.api.managers.GuildManager;
 import net.dv8tion.jda.api.managers.RoleManager;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.requests.restaction.AuditableRestAction;
@@ -117,6 +120,39 @@ public final class InverseAction
 
         else if (event instanceof GuildMemberUpdateNicknameEvent)
             return inverse((GuildMemberUpdateNicknameEvent) event);
+
+        else if (event instanceof GuildUpdateVanityCodeEvent)
+            return inverse((GuildUpdateVanityCodeEvent) event);
+
+        else if (event instanceof GuildUpdateMFALevelEvent)
+            return inverse((GuildUpdateMFALevelEvent) event);
+
+        else if (event instanceof GuildUpdateSystemChannelEvent)
+            return inverse((GuildUpdateSystemChannelEvent) event);
+
+        else if (event instanceof GuildUpdateRegionEvent)
+            return inverse((GuildUpdateRegionEvent) event);
+
+        else if (event instanceof GuildUpdateNameEvent)
+            return inverse((GuildUpdateNameEvent) event);
+
+        else if (event instanceof GuildUpdateDescriptionEvent )
+            return inverse((GuildUpdateDescriptionEvent) event);
+
+        else if (event instanceof GuildUpdateExplicitContentLevelEvent)
+            return inverse((GuildUpdateExplicitContentLevelEvent) event);
+
+        else if (event instanceof GuildUpdateNotificationLevelEvent)
+            return inverse((GuildUpdateNotificationLevelEvent) event);
+
+        else if (event instanceof GuildUpdateVerificationLevelEvent)
+            return inverse((GuildUpdateVerificationLevelEvent) event);
+
+        else if (event instanceof GuildUpdateAfkTimeoutEvent)
+            return inverse((GuildUpdateAfkTimeoutEvent) event);
+
+        else if (event instanceof GuildUpdateAfkChannelEvent)
+            return inverse((GuildUpdateAfkChannelEvent) event);
 
         else if (event instanceof GuildMemberJoinEvent)
             return inverse((GuildMemberJoinEvent) event);
@@ -309,7 +345,104 @@ public final class InverseAction
         return member.modifyNickname(oldNick);
     }
 
-    //TODO Look into all the GenericGuildUpdateEvents. There are a lot
+    private static GuildManager inverse(GuildUpdateVanityCodeEvent event)
+    {
+        Guild guild = event.getGuild();
+        GuildManager manager = guild.getManager();
+        String oldCode = event.getOldVanityCode();
+
+        return manager.setVanityCode(oldCode);
+    }
+
+    private static GuildManager inverse(GuildUpdateMFALevelEvent event)
+    {
+        Guild guild = event.getGuild();
+        GuildManager manager = guild.getManager();
+        Guild.MFALevel oldMFA = event.getOldMFALevel();
+
+        return manager.setRequiredMFALevel(oldMFA);
+    }
+
+    private static GuildManager inverse(GuildUpdateSystemChannelEvent event)
+    {
+        Guild guild = event.getGuild();
+        GuildManager manager = guild.getManager();
+        TextChannel oldChannel = event.getOldSystemChannel();
+
+        return manager.setSystemChannel(oldChannel);
+    }
+
+    private static GuildManager inverse(GuildUpdateRegionEvent event)
+    {
+        Guild guild = event.getGuild();
+        GuildManager manager = guild.getManager();
+        Region oldRegion = event.getOldRegion();
+
+        return manager.setRegion(oldRegion);
+    }
+
+    private static GuildManager inverse(GuildUpdateNameEvent event)
+    {
+        Guild guild = event.getGuild();
+        GuildManager manager = guild.getManager();
+        String oldName = event.getOldName();
+
+        return manager.setName(oldName);
+    }
+
+    private static GuildManager inverse(GuildUpdateDescriptionEvent event)
+    {
+        Guild guild = event.getGuild();
+        GuildManager manager = guild.getManager();
+        String oldDescription = event.getOldDescription();
+
+        return manager.setDescription(oldDescription);
+    }
+
+    private static GuildManager inverse(GuildUpdateExplicitContentLevelEvent event)
+    {
+        Guild guild = event.getGuild();
+        GuildManager manager = guild.getManager();
+        Guild.ExplicitContentLevel oldLevel = event.getOldValue();
+
+        return manager.setExplicitContentLevel(oldLevel);
+    }
+
+    private static GuildManager inverse(GuildUpdateNotificationLevelEvent event)
+    {
+        Guild guild = event.getGuild();
+        GuildManager manager = guild.getManager();
+        Guild.NotificationLevel oldLevel = event.getOldNotificationLevel();
+
+        return manager.setDefaultNotificationLevel(oldLevel);
+    }
+
+    private static GuildManager inverse(GuildUpdateVerificationLevelEvent event)
+    {
+        Guild guild = event.getGuild();
+        GuildManager manager = guild.getManager();
+        Guild.VerificationLevel oldLevel = event.getOldVerificationLevel();
+
+        return manager.setVerificationLevel(oldLevel);
+    }
+
+    private static GuildManager inverse(GuildUpdateAfkTimeoutEvent event)
+    {
+        Guild guild = event.getGuild();
+        GuildManager manager = guild.getManager();
+        Guild.Timeout oldTimeout = event.getOldAfkTimeout();
+
+        return manager.setAfkTimeout(oldTimeout);
+    }
+
+    private static GuildManager inverse(GuildUpdateAfkChannelEvent event)
+    {
+        Guild guild = event.getGuild();
+        GuildManager manager = guild.getManager();
+        VoiceChannel oldChannel = event.getOldAfkChannel();
+
+        return manager.setAfkChannel(oldChannel);
+    }
 
     private static AuditableRestAction<Void> inverse(GuildMemberJoinEvent event)
     {

--- a/commons/src/main/java/com/jagrosh/jdautilities/commons/utils/InverseAction.java
+++ b/commons/src/main/java/com/jagrosh/jdautilities/commons/utils/InverseAction.java
@@ -362,11 +362,11 @@ public final class InverseAction
     }
 
     /**
-     * @return An attempt to remove said channel
+     * @return An attempt to close said channel
      */
     public static RestAction<?> of(PrivateChannelCreateEvent event)
     {
-        return null;
+        return event.getChannel().close();
     }
 
     /**

--- a/commons/src/main/java/com/jagrosh/jdautilities/commons/utils/InverseAction.java
+++ b/commons/src/main/java/com/jagrosh/jdautilities/commons/utils/InverseAction.java
@@ -536,17 +536,17 @@ public final class InverseAction
     /**
      * @return An attempt to remove said reaction
      */
-    public static RestAction<?> of(MessageReactionAddEvent event)
+    public static RestAction<Void> of(MessageReactionAddEvent event)
     {
-        return null;
+        return event.getReaction().removeReaction();
     }
 
     /**
      * @return An attempt to remove said message
      */
-    public static RestAction<?> of(MessageReceivedEvent event)
+    public static AuditableRestAction<Void> of(MessageReceivedEvent event)
     {
-        return null;
+        return event.getMessage().delete();
     }
 
     // I'm not really sure what to do about store channels.

--- a/commons/src/main/java/com/jagrosh/jdautilities/commons/utils/InverseAction.java
+++ b/commons/src/main/java/com/jagrosh/jdautilities/commons/utils/InverseAction.java
@@ -122,7 +122,7 @@ public final class InverseAction
      */
     public static RestAction<?> of(GuildJoinEvent event)
     {
-        return null;
+        return event.getGuild().leave();
     }
 
     /**

--- a/commons/src/main/java/com/jagrosh/jdautilities/commons/utils/InverseAction.java
+++ b/commons/src/main/java/com/jagrosh/jdautilities/commons/utils/InverseAction.java
@@ -1,5 +1,8 @@
 package com.jagrosh.jdautilities.commons.utils;
 
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.events.channel.category.CategoryCreateEvent;
 import net.dv8tion.jda.api.events.channel.category.update.CategoryUpdateNameEvent;
 import net.dv8tion.jda.api.events.channel.category.update.CategoryUpdatePositionEvent;
@@ -38,6 +41,8 @@ import net.dv8tion.jda.api.events.self.*;
 import net.dv8tion.jda.api.managers.ChannelManager;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.requests.restaction.AuditableRestAction;
+
+import java.util.List;
 
 /**
  * A utility class meant to serve as a way to rollback certain events where it makes sense to.
@@ -113,7 +118,7 @@ public final class InverseAction
     /**
      * @return An attempt to take said roles away
      */
-    public static RestAction<?> of(GuildMemberRoleAddEvent event)
+    public static AuditableRestAction<Void> of(GuildMemberRoleAddEvent event)
     {
         Guild guild = event.getGuild();
         Member member = event.getMember();
@@ -125,7 +130,7 @@ public final class InverseAction
     /**
      * @return An attempt to give the member the roles back
      */
-    public static RestAction<?> of(GuildMemberRoleRemoveEvent event)
+    public static AuditableRestAction<Void> of(GuildMemberRoleRemoveEvent event)
     {
         Guild guild = event.getGuild();
         Member member = event.getMember();
@@ -137,7 +142,7 @@ public final class InverseAction
     /**
      * @return An attempt to change the member's nickname back
      */
-    public static RestAction<?> of(GuildMemberUpdateNicknameEvent event)
+    public static AuditableRestAction<Void> of(GuildMemberUpdateNicknameEvent event)
     {
         Member member = event.getMember();
         String oldNick = event.getOldNickname();
@@ -150,7 +155,7 @@ public final class InverseAction
     /**
      * @return An attempt to kick said member
      */
-    public static RestAction<?> of(GuildMemberJoinEvent event)
+    public static AuditableRestAction<Void> of(GuildMemberJoinEvent event)
     {
         return event.getMember().kick();
     }

--- a/commons/src/main/java/com/jagrosh/jdautilities/commons/utils/InverseAction.java
+++ b/commons/src/main/java/com/jagrosh/jdautilities/commons/utils/InverseAction.java
@@ -19,6 +19,7 @@ import net.dv8tion.jda.api.events.emote.update.EmoteUpdateNameEvent;
 import net.dv8tion.jda.api.events.emote.update.EmoteUpdateRolesEvent;
 import net.dv8tion.jda.api.events.guild.GuildBanEvent;
 import net.dv8tion.jda.api.events.guild.GuildJoinEvent;
+import net.dv8tion.jda.api.events.guild.GuildUnbanEvent;
 import net.dv8tion.jda.api.events.guild.invite.GuildInviteCreateEvent;
 import net.dv8tion.jda.api.events.guild.member.GuildMemberJoinEvent;
 import net.dv8tion.jda.api.events.guild.member.GuildMemberRoleAddEvent;
@@ -127,9 +128,20 @@ public final class InverseAction
     }
 
     /**
+     * @return An attempt to unban them
+     */
+    public static RestAction<Void> of(GuildBanEvent event)
+    {
+        Guild guild = event.getGuild();
+        User user = event.getUser();
+
+        return guild.unban(user);
+    }
+
+    /**
      * @return An attempt to ban them again (0 message deletion days will be assumed)
      */
-    public static AuditableRestAction<Void> of(GuildBanEvent event)
+    public static AuditableRestAction<Void> of(GuildUnbanEvent event)
     {
         Guild guild = event.getGuild();
         User user = event.getUser();
@@ -140,7 +152,7 @@ public final class InverseAction
     /**
      * @return An attempt to ban them again
      */
-    public static AuditableRestAction<Void> of(GuildBanEvent event, int delDays)
+    public static AuditableRestAction<Void> of(GuildUnbanEvent event, int delDays)
     {
         Guild guild = event.getGuild();
         User user = event.getUser();

--- a/commons/src/main/java/com/jagrosh/jdautilities/commons/utils/InverseAction.java
+++ b/commons/src/main/java/com/jagrosh/jdautilities/commons/utils/InverseAction.java
@@ -352,7 +352,7 @@ public final class InverseAction
     /**
      * @return An attempt to change the role's color back to what it just was
      */
-    public static RestAction<?> of(RoleUpdateColorEvent event)
+    public static RoleManager of(RoleUpdateColorEvent event)
     {
         Role role = event.getRole();
         RoleManager manager = role.getManager();
@@ -364,7 +364,7 @@ public final class InverseAction
     /**
      * @return An attempt to close said channel
      */
-    public static RestAction<?> of(PrivateChannelCreateEvent event)
+    public static RestAction<Void> of(PrivateChannelCreateEvent event)
     {
         return event.getChannel().close();
     }

--- a/commons/src/main/java/com/jagrosh/jdautilities/commons/utils/InverseAction.java
+++ b/commons/src/main/java/com/jagrosh/jdautilities/commons/utils/InverseAction.java
@@ -2,6 +2,7 @@ package com.jagrosh.jdautilities.commons.utils;
 
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.*;
+import net.dv8tion.jda.api.events.GenericEvent;
 import net.dv8tion.jda.api.events.channel.category.CategoryCreateEvent;
 import net.dv8tion.jda.api.events.channel.category.update.CategoryUpdateNameEvent;
 import net.dv8tion.jda.api.events.channel.category.update.CategoryUpdatePositionEvent;

--- a/commons/src/main/java/com/jagrosh/jdautilities/commons/utils/InverseEvent.java
+++ b/commons/src/main/java/com/jagrosh/jdautilities/commons/utils/InverseEvent.java
@@ -1,0 +1,489 @@
+package com.jagrosh.jdautilities.commons.utils;
+
+import net.dv8tion.jda.api.events.Event;
+import net.dv8tion.jda.api.events.channel.category.CategoryCreateEvent;
+import net.dv8tion.jda.api.events.channel.category.update.CategoryUpdateNameEvent;
+import net.dv8tion.jda.api.events.channel.category.update.CategoryUpdatePositionEvent;
+import net.dv8tion.jda.api.events.channel.priv.PrivateChannelCreateEvent;
+import net.dv8tion.jda.api.events.channel.store.StoreChannelCreateEvent;
+import net.dv8tion.jda.api.events.channel.store.update.StoreChannelUpdateNameEvent;
+import net.dv8tion.jda.api.events.channel.store.update.StoreChannelUpdatePositionEvent;
+import net.dv8tion.jda.api.events.channel.text.TextChannelCreateEvent;
+import net.dv8tion.jda.api.events.channel.text.TextChannelDeleteEvent;
+import net.dv8tion.jda.api.events.channel.text.update.*;
+import net.dv8tion.jda.api.events.channel.voice.VoiceChannelCreateEvent;
+import net.dv8tion.jda.api.events.channel.voice.VoiceChannelDeleteEvent;
+import net.dv8tion.jda.api.events.channel.voice.update.*;
+import net.dv8tion.jda.api.events.emote.EmoteAddedEvent;
+import net.dv8tion.jda.api.events.emote.update.EmoteUpdateNameEvent;
+import net.dv8tion.jda.api.events.emote.update.EmoteUpdateRolesEvent;
+import net.dv8tion.jda.api.events.guild.GuildJoinEvent;
+import net.dv8tion.jda.api.events.guild.GuildUnbanEvent;
+import net.dv8tion.jda.api.events.guild.invite.GuildInviteCreateEvent;
+import net.dv8tion.jda.api.events.guild.invite.GuildInviteDeleteEvent;
+import net.dv8tion.jda.api.events.guild.member.GuildMemberJoinEvent;
+import net.dv8tion.jda.api.events.guild.member.GuildMemberRoleAddEvent;
+import net.dv8tion.jda.api.events.guild.member.GuildMemberRoleRemoveEvent;
+import net.dv8tion.jda.api.events.guild.member.update.GuildMemberUpdateNicknameEvent;
+import net.dv8tion.jda.api.events.guild.override.PermissionOverrideCreateEvent;
+import net.dv8tion.jda.api.events.guild.override.PermissionOverrideDeleteEvent;
+import net.dv8tion.jda.api.events.guild.override.PermissionOverrideUpdateEvent;
+import net.dv8tion.jda.api.events.guild.voice.*;
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
+import net.dv8tion.jda.api.events.message.react.MessageReactionAddEvent;
+import net.dv8tion.jda.api.events.role.RoleCreateEvent;
+import net.dv8tion.jda.api.events.role.RoleDeleteEvent;
+import net.dv8tion.jda.api.events.role.update.*;
+import net.dv8tion.jda.api.events.self.*;
+import net.dv8tion.jda.api.managers.ChannelManager;
+import net.dv8tion.jda.api.requests.RestAction;
+import net.dv8tion.jda.api.requests.restaction.AuditableRestAction;
+
+/**
+ * A utility class meant to serve as a way to rollback certain events where it makes sense to.
+ *
+ * <p>
+ * All methods are overloaded static factory methods, always returning a {@link net.dv8tion.jda.api.requests.RestAction RestAction}
+ * meant to "undo" the given event. Note that this will only be possible for events in which it makes sense.
+ * In events where something is posted, the inverse would be another request to remove said post, for example.
+ *
+ * Also, since it's a RestAction that simply makes an attempt at the inverse, it's not always possible due to multiple
+ * factors, such as permissions, etc. For example, trying to inverse a {@link net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent GuildMessageReceievedEvent} in a channel with no permission
+ * to remove messages will fail
+ * </p>
+ * <br>
+ * <p>
+ * Events fired when something is "created" like a {@link net.dv8tion.jda.api.events.guild.override.PermissionOverrideCreateEvent PermissionOverrideCreateEvent}
+ * can usually be logically inverted, by removing what was created.
+ *
+ * Events fired for the deletion of something are a different story. Some cases are logical, but many are not, like the
+ * removal of a text channel. Cases where the complete undoing of the event cannot be guaranteed are not implemented
+ * </p>
+ *
+ * @author HydroPage90
+ */
+public final class InverseEvent
+{
+    /**
+     * @return A {@link net.dv8tion.jda.api.managers.ChannelManager ChannelManager} action that will return the category
+     * to its old position
+     */
+    public static ChannelManager of(CategoryUpdatePositionEvent event)
+    {
+        ChannelManager manager = event.getCategory().getManager();
+        int oldPosition = event.getOldPosition();
+
+        return manager.setPosition(oldPosition);
+    }
+
+    /**
+     * @return An attempt to undo the update
+     */
+    public static ChannelManager of(CategoryUpdateNameEvent event)
+    {
+        ChannelManager manager = event.getCategory().getManager();
+        String oldName = event.getOldName();
+
+        return manager.setName(oldName);
+    }
+
+    /**
+     * @return An attempt to remove the category
+     */
+    public static AuditableRestAction<Void> of(CategoryCreateEvent event)
+    {
+        return event.getCategory().delete();
+    }
+
+    /**
+     * @return An attempt to remove the invite
+     */
+    public static AuditableRestAction<Void> of(GuildInviteCreateEvent event)
+    {
+        return event.getInvite().delete();
+    }
+
+    /**
+     * @return An attempt to leave the guild
+     */
+    public static RestAction<?> of(GuildJoinEvent event)
+    {
+        return null;
+    }
+
+    /**
+     * @return An attempt to take the role away
+     */
+    public static RestAction<?> of(GuildMemberRoleAddEvent event)
+    {
+        return null;
+    }
+
+    /**
+     * @return An attempt to add the role back
+     */
+    public static RestAction<?> of(GuildMemberRoleRemoveEvent event)
+    {
+        return null;
+    }
+
+    /**
+     * @return An attempt to undo the nickname update
+     */
+    public static RestAction<?> of(GuildMemberUpdateNicknameEvent event)
+    {
+        return null;
+    }
+
+    //TODO Look into all the GenericGuildUpdateEvents. There are a lot
+
+    /**
+     * @return An attempt to kick the member
+     */
+    public static RestAction<?> of(GuildMemberJoinEvent event)
+    {
+        return null;
+    }
+
+    /**
+     * @return An attempt to ban them again
+     */
+    public static RestAction<?> of(GuildUnbanEvent event)
+    {
+        return null;
+    }
+
+    /**
+     * @return An attempt to undeafen if they were deafened, or an attempt to deafen if they were undeafened
+     */
+    public static RestAction<?> of(GuildVoiceGuildDeafenEvent event)
+    {
+        return null;
+    }
+
+    /**
+     * @return An attempt to kick them from the channel
+     */
+    public static RestAction<?> of(GuildVoiceJoinEvent event)
+    {
+        return null;
+    }
+
+    /**
+     * @return An attempt to move them back to where they just were
+     */
+    public static RestAction<?> of(GuildVoiceMoveEvent event)
+    {
+        return null;
+    }
+
+    /**
+     * @return An attempt to unmute if they were muted, or an attempt to mute if they were unmuted
+     */
+    public static RestAction<?> of(GuildVoiceGuildMuteEvent event)
+    {
+        return null;
+    }
+
+    /**
+     * @return An attempt to remove said override
+     */
+    public static RestAction<?> of(PermissionOverrideCreateEvent event)
+    {
+        return null;
+    }
+
+    /**
+     * @return An attempt to add the override back
+     */
+    public static RestAction<?> of(PermissionOverrideDeleteEvent event)
+    {
+        return null;
+    }
+
+    /**
+     * @return An attempt to set rules to what they just were
+     */
+    public static RestAction<?> of(PermissionOverrideUpdateEvent event)
+    {
+        return null;
+    }
+
+    /**
+     * @return An attempt to remove said emote
+     */
+    public static RestAction<?> of(EmoteAddedEvent event)
+    {
+        return null;
+    }
+
+    /**
+     * @return An attempt to change the name back to what it just was
+     */
+    public static RestAction<?> of(EmoteUpdateNameEvent event)
+    {
+        return null;
+    }
+
+    /**
+     * @return An attempt to change the roles to what they just were
+     */
+    public static RestAction<?> of(EmoteUpdateRolesEvent event)
+    {
+        return null;
+    }
+
+    /**
+     * @return An attempt to remove said role
+     */
+    public static RestAction<?> of(RoleCreateEvent event)
+    {
+        return null;
+    }
+
+    /**
+     * @return An attempt to add the role back
+     */
+    public static RestAction<?> of(RoleDeleteEvent event)
+    {
+        return null;
+    }
+
+    /**
+     * @return An attempt to make the role unmentionable again
+     */
+    public static RestAction<?> of(RoleUpdateMentionableEvent event)
+    {
+        return null;
+    }
+
+    /**
+     * @return An attempt to move the role back to where it just was
+     */
+    public static RestAction<?> of(RoleUpdatePositionEvent event)
+    {
+        return null;
+    }
+
+    /**
+     * @return An attempt to change the role's permissions back
+     */
+    public static RestAction<?> of(RoleUpdatePermissionsEvent event)
+    {
+        return null;
+    }
+
+    /**
+     * @return An attempt to change the role's name back
+     */
+    public static RestAction<?> of(RoleUpdateNameEvent event)
+    {
+        return null;
+    }
+
+    //TODO What the hell is a hoisted role? Lmao, look at that later
+
+    /**
+     * @return An attempt to change the role's color back to what it just was
+     */
+    public static RestAction<?> of(RoleUpdateColorEvent event)
+    {
+        return null;
+    }
+
+    /**
+     * @return An attempt to remove said channel
+     */
+    public static RestAction<?> of(PrivateChannelCreateEvent event)
+    {
+        return null;
+    }
+
+    // I'm not sure what this is, but keeping it here for now
+    public static RestAction<?> of(SelfUpdateDiscriminatorEvent event)
+    {
+        return null;
+    }
+
+    /**
+     * @return An attempt to change the avatar back
+     */
+    public static RestAction<?> of(SelfUpdateAvatarEvent event)
+    {
+        return null;
+    }
+
+    // Don't know what this is either
+    public static RestAction<?> of(SelfUpdateMFAEvent event)
+    {
+        return null;
+    }
+
+    /**
+     * @return An attempt to change the name back
+     */
+    public static RestAction<?> of(SelfUpdateNameEvent event)
+    {
+        return null;
+    }
+
+    // Not sure what this is
+    public static RestAction<?> of(SelfUpdateVerifiedEvent event)
+    {
+        return null;
+    }
+
+    /**
+     * @return An attempt to make the channel again
+     */
+    public static RestAction<?> of(VoiceChannelDeleteEvent event)
+    {
+        return null;
+    }
+
+    /**
+     * @return An attempt to remove said channel
+     */
+    public static RestAction<?> of(VoiceChannelCreateEvent event)
+    {
+        return null;
+    }
+
+    /**
+     * @return An attempt to change the voice channel's name back
+     */
+    public static RestAction<?> of(VoiceChannelUpdateNameEvent event)
+    {
+        return null;
+    }
+
+    /**
+     * @return An attempt to change the voice channel's parent back
+     */
+    public static RestAction<?> of(VoiceChannelUpdateParentEvent event)
+    {
+        return null;
+    }
+
+    /**
+     * @return An attempt to change the voice channel's position back
+     */
+    public static RestAction<?> of(VoiceChannelUpdatePositionEvent event)
+    {
+        return null;
+    }
+
+    /**
+     * @return An attempt to change the voice channel's bitrate back
+     */
+    public static RestAction<?> of(VoiceChannelUpdateBitrateEvent event)
+    {
+        return null;
+    }
+
+    /**
+     * @return An attempt to change the voice channel's user limit back
+     */
+    public static RestAction<?> of(VoiceChannelUpdateUserLimitEvent event)
+    {
+        return null;
+    }
+
+    /**
+     * @return An attempt to remove said channel
+     */
+    public static RestAction<?> of(TextChannelCreateEvent event)
+    {
+        return null;
+    }
+
+    /**
+     * @return An attempt to change the text channel's topic back
+     */
+    public static RestAction<?> of(TextChannelUpdateTopicEvent event)
+    {
+        return null;
+    }
+
+    /**
+     * @return An attempt to change the text channel's name back
+     */
+    public static RestAction<?> of(TextChannelUpdateNameEvent event)
+    {
+        return null;
+    }
+
+    /**
+     * @return An attempt to change the text channel's slowmode value back
+     */
+    public static RestAction<?> of(TextChannelUpdateSlowmodeEvent event)
+    {
+        return null;
+    }
+
+    /**
+     * @return An attempt to move the text channel back
+     */
+    public static RestAction<?> of(TextChannelUpdatePositionEvent event)
+    {
+        return null;
+    }
+
+    /**
+     * @return An attempt to change the text channel's NSFW state back
+     */
+    public static RestAction<?> of(TextChannelUpdateNSFWEvent event)
+    {
+        return null;
+    }
+
+    /**
+     * @return An attempt to change the text channel's parent back
+     */
+    public static RestAction<?> of(TextChannelUpdateParentEvent event)
+    {
+        return null;
+    }
+
+    /**
+     * @return An attempt to remove said reaction
+     */
+    public static RestAction<?> of(MessageReactionAddEvent event)
+    {
+        return null;
+    }
+
+    /**
+     * @return An attempt to remove said message
+     */
+    public static RestAction<?> of(MessageReceivedEvent event)
+    {
+        return null;
+    }
+
+    // I'm not really sure what to do about store channels.
+
+    /**
+     * @return An attempt to move the store channel back
+     */
+    public static RestAction<?> of(StoreChannelUpdatePositionEvent event)
+    {
+        return null;
+    }
+
+    /**
+     * @return An attempt to change the store channel's name back
+     */
+    public static RestAction<?> of(StoreChannelUpdateNameEvent event)
+    {
+        return null;
+    }
+
+    /**
+     * @return An attempt to remove said store channel
+     */
+    public static RestAction<?> of(StoreChannelCreateEvent event)
+    {
+        return null;
+    }
+}

--- a/commons/src/main/java/com/jagrosh/jdautilities/commons/utils/InverseEvent.java
+++ b/commons/src/main/java/com/jagrosh/jdautilities/commons/utils/InverseEvent.java
@@ -1,6 +1,5 @@
 package com.jagrosh.jdautilities.commons.utils;
 
-import net.dv8tion.jda.api.events.Event;
 import net.dv8tion.jda.api.events.channel.category.CategoryCreateEvent;
 import net.dv8tion.jda.api.events.channel.category.update.CategoryUpdateNameEvent;
 import net.dv8tion.jda.api.events.channel.category.update.CategoryUpdatePositionEvent;
@@ -9,7 +8,6 @@ import net.dv8tion.jda.api.events.channel.store.StoreChannelCreateEvent;
 import net.dv8tion.jda.api.events.channel.store.update.StoreChannelUpdateNameEvent;
 import net.dv8tion.jda.api.events.channel.store.update.StoreChannelUpdatePositionEvent;
 import net.dv8tion.jda.api.events.channel.text.TextChannelCreateEvent;
-import net.dv8tion.jda.api.events.channel.text.TextChannelDeleteEvent;
 import net.dv8tion.jda.api.events.channel.text.update.*;
 import net.dv8tion.jda.api.events.channel.voice.VoiceChannelCreateEvent;
 import net.dv8tion.jda.api.events.channel.voice.VoiceChannelDeleteEvent;
@@ -20,7 +18,6 @@ import net.dv8tion.jda.api.events.emote.update.EmoteUpdateRolesEvent;
 import net.dv8tion.jda.api.events.guild.GuildJoinEvent;
 import net.dv8tion.jda.api.events.guild.GuildUnbanEvent;
 import net.dv8tion.jda.api.events.guild.invite.GuildInviteCreateEvent;
-import net.dv8tion.jda.api.events.guild.invite.GuildInviteDeleteEvent;
 import net.dv8tion.jda.api.events.guild.member.GuildMemberJoinEvent;
 import net.dv8tion.jda.api.events.guild.member.GuildMemberRoleAddEvent;
 import net.dv8tion.jda.api.events.guild.member.GuildMemberRoleRemoveEvent;
@@ -28,7 +25,10 @@ import net.dv8tion.jda.api.events.guild.member.update.GuildMemberUpdateNicknameE
 import net.dv8tion.jda.api.events.guild.override.PermissionOverrideCreateEvent;
 import net.dv8tion.jda.api.events.guild.override.PermissionOverrideDeleteEvent;
 import net.dv8tion.jda.api.events.guild.override.PermissionOverrideUpdateEvent;
-import net.dv8tion.jda.api.events.guild.voice.*;
+import net.dv8tion.jda.api.events.guild.voice.GuildVoiceGuildDeafenEvent;
+import net.dv8tion.jda.api.events.guild.voice.GuildVoiceGuildMuteEvent;
+import net.dv8tion.jda.api.events.guild.voice.GuildVoiceJoinEvent;
+import net.dv8tion.jda.api.events.guild.voice.GuildVoiceMoveEvent;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.events.message.react.MessageReactionAddEvent;
 import net.dv8tion.jda.api.events.role.RoleCreateEvent;
@@ -65,8 +65,7 @@ import net.dv8tion.jda.api.requests.restaction.AuditableRestAction;
 public final class InverseEvent
 {
     /**
-     * @return A {@link net.dv8tion.jda.api.managers.ChannelManager ChannelManager} action that will return the category
-     * to its old position
+     * @return An attempt to change the category's position back
      */
     public static ChannelManager of(CategoryUpdatePositionEvent event)
     {
@@ -77,7 +76,7 @@ public final class InverseEvent
     }
 
     /**
-     * @return An attempt to undo the update
+     * @return An attempt to change the category's name back
      */
     public static ChannelManager of(CategoryUpdateNameEvent event)
     {
@@ -88,7 +87,7 @@ public final class InverseEvent
     }
 
     /**
-     * @return An attempt to remove the category
+     * @return An attempt to remove said category
      */
     public static AuditableRestAction<Void> of(CategoryCreateEvent event)
     {
@@ -96,7 +95,7 @@ public final class InverseEvent
     }
 
     /**
-     * @return An attempt to remove the invite
+     * @return An attempt to remove said invite
      */
     public static AuditableRestAction<Void> of(GuildInviteCreateEvent event)
     {
@@ -104,7 +103,7 @@ public final class InverseEvent
     }
 
     /**
-     * @return An attempt to leave the guild
+     * @return An attempt to leave said guild
      */
     public static RestAction<?> of(GuildJoinEvent event)
     {
@@ -112,7 +111,7 @@ public final class InverseEvent
     }
 
     /**
-     * @return An attempt to take the role away
+     * @return An attempt to take said role away
      */
     public static RestAction<?> of(GuildMemberRoleAddEvent event)
     {
@@ -120,7 +119,7 @@ public final class InverseEvent
     }
 
     /**
-     * @return An attempt to add the role back
+     * @return An attempt to give the member the role back
      */
     public static RestAction<?> of(GuildMemberRoleRemoveEvent event)
     {
@@ -128,7 +127,7 @@ public final class InverseEvent
     }
 
     /**
-     * @return An attempt to undo the nickname update
+     * @return An attempt to change the member's nickname back
      */
     public static RestAction<?> of(GuildMemberUpdateNicknameEvent event)
     {
@@ -138,7 +137,7 @@ public final class InverseEvent
     //TODO Look into all the GenericGuildUpdateEvents. There are a lot
 
     /**
-     * @return An attempt to kick the member
+     * @return An attempt to kick said member
      */
     public static RestAction<?> of(GuildMemberJoinEvent event)
     {
@@ -146,7 +145,7 @@ public final class InverseEvent
     }
 
     /**
-     * @return An attempt to ban them again
+     * @return An attempt to ban said member again
      */
     public static RestAction<?> of(GuildUnbanEvent event)
     {

--- a/commons/src/main/java/com/jagrosh/jdautilities/commons/utils/InverseEvent.java
+++ b/commons/src/main/java/com/jagrosh/jdautilities/commons/utils/InverseEvent.java
@@ -298,40 +298,6 @@ public final class InverseEvent
         return null;
     }
 
-    // I'm not sure what this is, but keeping it here for now
-    public static RestAction<?> of(SelfUpdateDiscriminatorEvent event)
-    {
-        return null;
-    }
-
-    /**
-     * @return An attempt to change the avatar back
-     */
-    public static RestAction<?> of(SelfUpdateAvatarEvent event)
-    {
-        return null;
-    }
-
-    // Don't know what this is either
-    public static RestAction<?> of(SelfUpdateMFAEvent event)
-    {
-        return null;
-    }
-
-    /**
-     * @return An attempt to change the name back
-     */
-    public static RestAction<?> of(SelfUpdateNameEvent event)
-    {
-        return null;
-    }
-
-    // Not sure what this is
-    public static RestAction<?> of(SelfUpdateVerifiedEvent event)
-    {
-        return null;
-    }
-
     /**
      * @return An attempt to make the channel again
      */


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing
[pull-request]: https://github.com/JDA-Applications/JDA-Utilities/pulls

## Pull Request

#### Pull Request Checklist

- [x] I have checked the [pull request page][pull-request] for upcoming
      or merged features/bug fixes.
- [x] I have read JDA's [contributing guidelines][contributing].

#### Pull Request Information

- [ ] My PR fixes a bug, error, or other issue with the library's codebase.
- [x] My PR is for the `commons` module of the JDA-Utilities library.
- [ ] My PR creates a new module for the JDA-Utilities library: `______`.

#### Description

I have begun implementing a utility class I have, as of now, named `InverseAction`. I have explained the granular details in the class' javadoc, but I can summarize here. This util class' contract promises to return a `RestAction<?>` that will effectively wrap the "undoing" of a given input event type. This is to clean the instances where you want to detect an event, and revert its effects if the context around the event meets certain causes, etc.

Again, this will only be implemented for events in which it makes sense to fully be able to "undo" an action that was done.
The removal of a voice channel can be undone effectively; however, the removal of a text channel cannot, and will not be included.

I have sifted carefully through every event in JDA (There are some I'm still not sure of, I believe) to include only the events  that can be logically reverted by the bot.

I have included the implementation of a couple of the first methods in the class so you can get a full understanding of what I mean. I hope you will accept my feature proposal